### PR TITLE
159 zaporne souradnice

### DIFF
--- a/src/main/java/cz/geokuk/core/coordinates/Wgs.java
+++ b/src/main/java/cz/geokuk/core/coordinates/Wgs.java
@@ -148,7 +148,8 @@ public class Wgs extends Misto0 {
 
 	@Override
 	public String toString() {
-		return "N" + toGeoFormat(lat) + " E" + toGeoFormat(lon);
+		// Úprava pro záporné souřadnice
+		return (lat >= 0 ? "N" : "S") + toGeoFormat(Math.abs(lat)) + " " + (lon >= 0 ? "E" : "W") + toGeoFormat(Math.abs(lon));
 	}
 
 	@Override

--- a/src/main/java/cz/geokuk/core/coordinates/WgsParser.java
+++ b/src/main/java/cz/geokuk/core/coordinates/WgsParser.java
@@ -113,9 +113,6 @@ public class WgsParser {
 			case 'S':
 			case 'W':
 			case '-': // povoluje se také mínus pro záporné souřadnice
-/*			case 'V':
-			case 'J':
-			case 'Z':  */
 				return pismeno; // to tam smí být
 			}
 			return null; // je tam špatné písmeno

--- a/src/main/java/cz/geokuk/core/coordinates/WgsParser.java
+++ b/src/main/java/cz/geokuk/core/coordinates/WgsParser.java
@@ -89,13 +89,17 @@ public class WgsParser {
 
 		double toDouble() {
 			final double x = stupne.toDouble() + minuty.toDouble() / 60 + vteriny.toDouble() / 3600;
+			final Character c = pismenoSvetovychStran();
+			if ("-SW".indexOf(c) >= 0) {  // tehdy jsou souřadnice záporné
+				return -x;
+			}
 			return x;
 		}
 
 		private Character extrahujJedinePovolenePismeno(final String s) {
 			Character pismeno = ' '; // to znamená žádné písmeno tam nebylo
 			for (int i = 0; i < s.length(); i++) {
-				if (Character.isLetter(s.charAt(i))) {
+				if (Character.isLetter(s.charAt(i)) || s.charAt(i) == '-') {
 					if (pismeno != ' ' && pismeno != s.charAt(i)) {
 						return null; // je tam druhé písmeno
 					}
@@ -108,9 +112,10 @@ public class WgsParser {
 			case 'E':
 			case 'S':
 			case 'W':
-			case 'V':
+			case '-': // povoluje se také mínus pro záporné souřadnice
+/*			case 'V':
 			case 'J':
-			case 'Z':
+			case 'Z':  */
 				return pismeno; // to tam smí být
 			}
 			return null; // je tam špatné písmeno
@@ -186,19 +191,24 @@ public class WgsParser {
 		povolVariaci('S', 'E');
 		povolVariaci('S', 'W');
 
+		povolVariaci('-', ' ');
+		povolVariaci(' ', '-');
+		povolVariaci('-', '-');
+
 		// české
-		povolVariaci('S', 'V');
+/*		povolVariaci('S', 'V');
 		povolVariaci('S', 'Z');
 		povolVariaci('J', 'V');
-		povolVariaci('J', 'Z');
+		povolVariaci('J', 'Z');  */
 
 		// jednostranné
 		povolVariaci('N', ' ');
+		povolVariaci('S', ' ');
 		povolVariaci(' ', 'E');
 		povolVariaci(' ', 'W');
-		povolVariaci('J', ' ');
+/*		povolVariaci('J', ' ');
 		povolVariaci(' ', 'Z');
-		povolVariaci(' ', 'V');
+		povolVariaci(' ', 'V');  */
 	}
 
 	public static void main(final String[] args) {
@@ -330,17 +340,24 @@ public class WgsParser {
 			return null;
 		}
 
+		boolean vymenitSouradnice = false;
+
 		for (final PovolenaVariacePismen povapi : povoleneVariace) {
 			if (povapi.p1 == pismeno1 && povapi.p2 == pismeno2) {
 				return v; // je to OK
 			}
 			if (povapi.p1 == pismeno2 && povapi.p2 == pismeno1) {
-				final Souradky pom = v.sou1;
-				v.sou1 = v.sou2;
-				v.sou2 = pom;
-				return v; // je to OK, ale msueli jsme vyměnit strany
+				vymenitSouradnice = true;
 			}
 		}
+
+		if (vymenitSouradnice) {
+			final Souradky pom = v.sou1;
+			v.sou1 = v.sou2;
+			v.sou2 = pom;
+			return v; // je to OK, ale museli jsme vyměnit strany
+		}
+
 		return null; // neprošlo sítem písmen
 	}
 

--- a/src/main/java/cz/geokuk/core/coordinates/WgsParser.java
+++ b/src/main/java/cz/geokuk/core/coordinates/WgsParser.java
@@ -195,20 +195,11 @@ public class WgsParser {
 		povolVariaci(' ', '-');
 		povolVariaci('-', '-');
 
-		// české
-/*		povolVariaci('S', 'V');
-		povolVariaci('S', 'Z');
-		povolVariaci('J', 'V');
-		povolVariaci('J', 'Z');  */
-
 		// jednostranné
 		povolVariaci('N', ' ');
 		povolVariaci('S', ' ');
 		povolVariaci(' ', 'E');
 		povolVariaci(' ', 'W');
-/*		povolVariaci('J', ' ');
-		povolVariaci(' ', 'Z');
-		povolVariaci(' ', 'V');  */
 	}
 
 	public static void main(final String[] args) {

--- a/src/main/java/cz/geokuk/core/render/JRenderDialog.java
+++ b/src/main/java/cz/geokuk/core/render/JRenderDialog.java
@@ -521,15 +521,19 @@ public class JRenderDialog extends JMyDialog0 implements AfterInjectInit, AfterE
 			final SortedMap<String, String> pats = new TreeMap<>();
 			pats.put("C1-wgs", wgs + " z" + moumer);
 			pats.put("C2-utm", wgs.toUtm().toString() + " z" + moumer);
-			pats.put("C3-vter", "N" + Wgs.toDdMmSsFormat(wgs.lat) + " E" + Wgs.toDdMmSsFormat(wgs.lon) + " z" + moumer);
+			pats.put("C3-vter", (wgs.lat >= 0 ? "N" : "S") + Wgs.toDdMmSsFormat(Math.abs(wgs.lat)) + " " + (wgs.lon >= 0 ? "E" : "W") + Wgs.toDdMmSsFormat(Math.abs(wgs.lon)) + " z" + moumer);
 			jKmzFolderNazevCombo.addPatterns(pats, smazatGeocodingPatterns ? JGeocodingComboBox.PRAZDNE_GEOTAGGINGG_PATTERNS : null);
 		}
 		{
 			final SortedMap<String, String> pats = new TreeMap<>();
-			pats.put("C0-compact", String.format(Locale.ENGLISH, "n%7fe%7fz%d", wgs.lat, wgs.lon, moumer).replace(".", ""));
+			pats.put("C0-compact", String.format(Locale.ENGLISH, "%c%7f%c%7fz%d",
+					(wgs.lat >= 0 ? 'n' : 's'), Math.abs(wgs.lat), 
+					(wgs.lon >= 0 ? 'e' : 'w'), Math.abs(wgs.lon), moumer).replace(".", ""));
 			pats.put("C1-wgs", wgs + " z" + moumer);
 			pats.put("C2-utm", wgs.toUtm().toString());
-			pats.put("C3-vter", FUtil.vycistiJmenoSouboru("N" + Wgs.toDdMmSsFormat(wgs.lat) + " E" + Wgs.toDdMmSsFormat(wgs.lon) + " z" + moumer));
+			pats.put("C3-vter", FUtil.vycistiJmenoSouboru(
+			        (wgs.lat >= 0 ? "N" : "S") + Wgs.toDdMmSsFormat(Math.abs(wgs.lat)) + " " + 
+			        (wgs.lon >= 0 ? "E" : "W") + Wgs.toDdMmSsFormat(Math.abs(wgs.lon)) + " z" + moumer));
 			jPureJmenoSouboruCombo.addPatterns(pats, smazatGeocodingPatterns ? JGeocodingComboBox.PRAZDNE_GEOTAGGINGG_PATTERNS : null);
 		}
 	}

--- a/src/main/java/cz/geokuk/plugins/kesoid/hledani/JSouradnicovyFrame.java
+++ b/src/main/java/cz/geokuk/plugins/kesoid/hledani/JSouradnicovyFrame.java
@@ -61,6 +61,8 @@ public class JSouradnicovyFrame extends JMyDialog0 implements AfterEventReceiver
 			jSouEdit.setBackground(entryBg);
 		}
 	}
+	private static final String NS = "NS";
+	private static final String EW = "EW";
 
 	private static final Double SPATNY_FORMAT = Double.NEGATIVE_INFINITY;
 
@@ -265,8 +267,8 @@ public class JSouradnicovyFrame extends JMyDialog0 implements AfterEventReceiver
 		}
 		final double lat = wgs == null ? SPATNY_FORMAT : wgs.lat;
 		final double lon = wgs == null ? SPATNY_FORMAT : wgs.lon;
-		final boolean okSirka = aplikuj(jHotovaSirka, jSouEdit, lat, SIRKA_MIN, SIRKA_MAX, "NS");
-		final boolean okDelka = aplikuj(jHotovaDelka, jSouEdit, lon, DELKA_MIN, DELKA_MAX, "EW");
+		final boolean okSirka = aplikuj(jHotovaSirka, jSouEdit, lat, SIRKA_MIN, SIRKA_MAX, NS);
+		final boolean okDelka = aplikuj(jHotovaDelka, jSouEdit, lon, DELKA_MIN, DELKA_MAX, EW);
 		ok = okSirka && okDelka;
 		if (ok) {
 			souradniceEditovane = wgs;

--- a/src/main/java/cz/geokuk/plugins/kesoid/hledani/JSouradnicovyFrame.java
+++ b/src/main/java/cz/geokuk/plugins/kesoid/hledani/JSouradnicovyFrame.java
@@ -162,9 +162,9 @@ public class JSouradnicovyFrame extends JMyDialog0 implements AfterEventReceiver
 
 	@Override
 	protected void initComponents() {
-		final String tooltip = "Šířku i délku zadáváte jak jedno až tři celá nebo desetinná čísla (stupně, minuty, vteřiny),"
-		        + " jako oddělovač použijte mezeru nebo odpovídající značky °'\". Jako oddělovač desetin můžete použít tečku nebo čárku. "
-		        + " Písmena N nebo E můžete uvést na začátku, na knoci nebo je vynechat. (Nelze zadávat jižní šířku, či západní délku.)";
+		final String tooltip = "<html>Šířku i délku zadáváte jak jedno až tři celá nebo desetinná čísla (stupně, minuty, vteřiny),"
+		        + "<br/>jako oddělovač použijte mezeru nebo odpovídající značky °'\".<br/>Jako oddělovač desetin můžete použít tečku nebo čárku."
+		        + "<br/>Písmena N nebo E můžete uvést na začátku, na konci nebo je vynechat.<br/>Pro jižní šířku zadejte S, pro západní délku zadejte W.</html>";
 		jSouEdit = new JTextField();
 		jSouEdit.setToolTipText(tooltip);
 
@@ -220,7 +220,7 @@ public class JSouradnicovyFrame extends JMyDialog0 implements AfterEventReceiver
 
 	}
 
-	private boolean aplikuj(final JLabel jHotova, final JTextField editacni, final double val, final double min, final double max) {
+	private boolean aplikuj(final JLabel jHotova, final JTextField editacni, final double val, final double min, final double max, final String pismena) {
 		boolean ok;
 		if (val == SPATNY_FORMAT) {
 			jHotova.setText("Grrrr!");
@@ -228,7 +228,7 @@ public class JSouradnicovyFrame extends JMyDialog0 implements AfterEventReceiver
 			editacni.setBackground(ERROR_COLOR);
 			ok = false;
 		} else {
-			jHotova.setText(Wgs.toGeoFormat(val));
+			jHotova.setText(pismena.charAt(val >= 0 ? 0 : 1) + Wgs.toGeoFormat(Math.abs(val)));
 			if (val >= min && val <= max) {
 				jHotova.setBackground(Color.GREEN);
 				editacni.setBackground(Color.WHITE);
@@ -265,8 +265,8 @@ public class JSouradnicovyFrame extends JMyDialog0 implements AfterEventReceiver
 		}
 		final double lat = wgs == null ? SPATNY_FORMAT : wgs.lat;
 		final double lon = wgs == null ? SPATNY_FORMAT : wgs.lon;
-		final boolean okSirka = aplikuj(jHotovaSirka, jSouEdit, lat, SIRKA_MIN, SIRKA_MAX);
-		final boolean okDelka = aplikuj(jHotovaDelka, jSouEdit, lon, DELKA_MIN, DELKA_MAX);
+		final boolean okSirka = aplikuj(jHotovaSirka, jSouEdit, lat, SIRKA_MIN, SIRKA_MAX, "NS");
+		final boolean okDelka = aplikuj(jHotovaDelka, jSouEdit, lon, DELKA_MIN, DELKA_MAX, "EW");
 		ok = okSirka && okDelka;
 		if (ok) {
 			souradniceEditovane = wgs;
@@ -312,7 +312,8 @@ public class JSouradnicovyFrame extends JMyDialog0 implements AfterEventReceiver
 		}
 		souradniceReferencni = wgs;
 		if (!souradniceNastavenyRukama) {
-			jSouEdit.setText(Wgs.toGeoFormat(wgs.lat) + " ; " + Wgs.toGeoFormat(wgs.lon));
+			jSouEdit.setText(wgs.toString());
+//			jSouEdit.setText(Wgs.toGeoFormat(wgs.lat) + " ; " + Wgs.toGeoFormat(wgs.lon));
 			jSouEdit.selectAll();
 			souradniceNastavenyRukama = false; // toto se může zdát zbytečné, ale řádky před tím to změní
 		}

--- a/src/main/java/cz/geokuk/plugins/mrizky/JMrizkaDdMmMmm.java
+++ b/src/main/java/cz/geokuk/plugins/mrizky/JMrizkaDdMmMmm.java
@@ -22,12 +22,12 @@ public class JMrizkaDdMmMmm extends JMrizkaWgs {
 
 	@Override
 	public String getTextX(final double x) {
-		return Wgs.toGeoFormat(x);
+		return (x < 0 ? "-" : "") + Wgs.toGeoFormat(Math.abs(x));
 	}
 
 	@Override
 	public String getTextY(final double y) {
-		return Wgs.toGeoFormat(y);
+		return (y < 0 ? "-" : "") + Wgs.toGeoFormat(Math.abs(y));
 	}
 
 	/*

--- a/src/main/java/cz/geokuk/plugins/mrizky/JMrizkaDdMmSs.java
+++ b/src/main/java/cz/geokuk/plugins/mrizky/JMrizkaDdMmSs.java
@@ -19,12 +19,12 @@ public class JMrizkaDdMmSs extends JMrizkaWgs {
 
 	@Override
 	public String getTextX(final double x) {
-		return Wgs.toDdMmSsFormat(x);
+		return (x < 0 ? "-" : "") + Wgs.toDdMmSsFormat(Math.abs(x));
 	}
 
 	@Override
 	public String getTextY(final double y) {
-		return Wgs.toDdMmSsFormat(y);
+		return (y < 0 ? "-" : "") + Wgs.toDdMmSsFormat(Math.abs(y));
 	}
 
 	/*


### PR DESCRIPTION
Opravena práce se zápornými souřadnicemi, tj. západní délkou a jižní šířkou.
Oprava provedena do zobrazení souřadnice, vyhledávání podle souřadnic a nabízení jména při renderování. Zároveň zrušeny české prefixy pro souřadnice (S, J, V, Z) jako nepoužívané a matoucí.

Souřadnice se ve WGS zobrazují klasicky s prefixem N/S a E/W, při zadávání do vyhledávání podle souřadnic je možné zadávat tuto notaci nebo desetinná čísla pro šířku a délku. V tomto případě se pro záporné souřadnice použije znaméno mínus (38.1234, -9.112233)

Nebyl změněn mapový podklad, tedy dá se čekat, že pro vzdálené oblasti nebudou mapy k dispozici nebo nebudou v takové přesnosti jako v ČR.