### PR TITLE
Konfigurovatelné mapy ála GME

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,16 @@
 		</plugins>
 	</build>
 
-	<repositories>
-		<repository>
-			<id>tmate</id>
-			<url>http://maven.tmatesoft.com/content/repositories/releases</url>
-		</repository>
-	</repositories>
+<!--	<repositories>-->
+<!--		<repository>-->
+<!--			<id>maven2</id>-->
+<!--			<url>https://repo1.maven.org/maven2/</url>-->
+<!--		</repository>-->
+<!--		<repository>-->
+<!--			<id>tmate</id>-->
+<!--			<url>https://maven.tmatesoft.com/content/repositories/releases</url>-->
+<!--		</repository>-->
+<!--	</repositories>-->
 
 	<dependencies>
 	
@@ -153,7 +157,24 @@
 		    <artifactId>reflections</artifactId>
 		    <version>0.9.10</version>
 		</dependency>
-				
+
+		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>2.15.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.25</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>1.7.25</version>
+		</dependency>
 	</dependencies>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/cz/geokuk/core/coord/VyrezModel.java
+++ b/src/main/java/cz/geokuk/core/coord/VyrezModel.java
@@ -155,6 +155,9 @@ public class VyrezModel extends Model0 {
 	}
 
 	private int nastavitelneMeritkoZChteneho(int moumer, final boolean autoMeritko) {
+		if (podkladMap == null) {
+			return 0;
+		}
 		moumer = FMath.fit(moumer, podkladMap.getMinMoumer(), autoMeritko ? podkladMap.getMaxAutoMoumer() : podkladMap.getMaxMoumer());
 		return moumer;
 	}

--- a/src/main/java/cz/geokuk/core/coord/VyrezModel.java
+++ b/src/main/java/cz/geokuk/core/coord/VyrezModel.java
@@ -9,7 +9,7 @@ import cz.geokuk.core.coordinates.*;
 import cz.geokuk.core.program.FPref;
 import cz.geokuk.framework.Model0;
 import cz.geokuk.plugins.mapy.ZmenaMapNastalaEvent;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 import cz.geokuk.util.lang.FMath;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,7 +27,7 @@ public class VyrezModel extends Model0 {
 
 	private PoziceModel poziceModel;
 
-	private EKaType podkladMap;
+	private KaType podkladMap;
 
 	private Coord moord = Coord.prozatimniInicializacni();
 

--- a/src/main/java/cz/geokuk/core/program/FPref.java
+++ b/src/main/java/cz/geokuk/core/program/FPref.java
@@ -60,6 +60,7 @@ public class FPref {
 	public static final String VALUE_MAPOVE_DEKORACE_value = "mapoveDekorace";
 
 	public static final String VALUE_MAPOVE_PODKLADY_value = "mapovePodklady";
+	public static final String VALUE_MAPOVE_PODKLADY_DEFINITIONS_FILE_value = "mapovePodkladyJson";
 	public static final String VSEOBECNE_node = "vseobecne";
 	public static final String ZOBRAZ_OBSAZENOST_value = "zobrazitObsazenost";
 

--- a/src/main/java/cz/geokuk/core/program/Inicializator.java
+++ b/src/main/java/cz/geokuk/core/program/Inicializator.java
@@ -10,8 +10,13 @@ import cz.geokuk.core.napoveda.NapovedaModel;
 import cz.geokuk.core.onoffline.OnofflineModel;
 import cz.geokuk.core.profile.ProfileModel;
 import cz.geokuk.core.render.RenderModel;
-import cz.geokuk.framework.*;
-import cz.geokuk.plugins.cesty.*;
+import cz.geokuk.framework.BeanBag;
+import cz.geokuk.framework.EventManager;
+import cz.geokuk.framework.Prefe;
+import cz.geokuk.framework.ProgressModel;
+import cz.geokuk.plugins.cesty.CestyModel;
+import cz.geokuk.plugins.cesty.CestyNacitaniKesoiduWatchDog;
+import cz.geokuk.plugins.cesty.CestyZperzistentnovac;
 import cz.geokuk.plugins.geocoding.GeocodingModel;
 import cz.geokuk.plugins.kesoid.KesoidFilterModel;
 import cz.geokuk.plugins.kesoid.kind.KesoidPluginManager;
@@ -19,23 +24,17 @@ import cz.geokuk.plugins.kesoid.mvc.KesoidModel;
 import cz.geokuk.plugins.kesoidkruhy.KruhyModel;
 import cz.geokuk.plugins.kesoidobsazenost.ObsazenostModel;
 import cz.geokuk.plugins.kesoidpopisky.PopiskyModel;
-import cz.geokuk.plugins.mapy.*;
+import cz.geokuk.plugins.mapy.MapyModel;
+import cz.geokuk.plugins.mapy.PodkladAction;
 import cz.geokuk.plugins.mapy.kachle.KachleModel;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
 import cz.geokuk.plugins.mapy.kachle.podklady.KachleZiskavac;
 import cz.geokuk.plugins.mapy.kachle.podklady.KachloDownloader;
 import cz.geokuk.plugins.mrizky.MrizkaModel;
 import cz.geokuk.plugins.refbody.HlidacReferencnihoBodu;
 import cz.geokuk.plugins.refbody.RefbodyModel;
-import cz.geokuk.plugins.vylety.*;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import static java.util.Arrays.asList;
+import cz.geokuk.plugins.vylety.VyletModel;
+import cz.geokuk.plugins.vylety.VyletNacitaniKesoiduWatchDog;
+import cz.geokuk.plugins.vylety.VyletovyZperzistentnovac;
 
 /**
  * @author Martin Veverka
@@ -81,7 +80,7 @@ public class Inicializator {
 		bb.registerSigleton(new KachloDownloader());
 
 		mapy = bb.registerSigleton(new MapyModel());
-		// Potřebuji mít MapyModel inicializovaný dřív, než proběhne bb.init()...
+		// WORKAROUND: Potřebuji mít MapyModel inicializovaný dřív, než proběhne bb.init()...
 		mapy.inject(ef);
 		mapy.inject(prefe);
 		//.

--- a/src/main/java/cz/geokuk/core/program/Inicializator.java
+++ b/src/main/java/cz/geokuk/core/program/Inicializator.java
@@ -119,6 +119,7 @@ public class Inicializator {
 	public void initMapAkce(final BeanBag bb, final Akce akce) {
 		mapy.init();
 		mapy.getMapy().stream()
+			.filter(kt -> !kt.isIgnored())
             .map(PodkladAction::new)
             .forEach(jednamapoakce -> {
                 akce.mapoakce.add(jednamapoakce);

--- a/src/main/java/cz/geokuk/core/program/Inicializator.java
+++ b/src/main/java/cz/geokuk/core/program/Inicializator.java
@@ -29,6 +29,8 @@ import cz.geokuk.plugins.refbody.HlidacReferencnihoBodu;
 import cz.geokuk.plugins.refbody.RefbodyModel;
 import cz.geokuk.plugins.vylety.*;
 
+import java.util.stream.Stream;
+
 /**
  * @author Martin Veverka
  *
@@ -104,12 +106,15 @@ public class Inicializator {
 	}
 
 	public void intMapAkce(final BeanBag bb, final Akce akce) {
-		for (final EKaType ka : EKaType.values()) {
-			final MapyAction0 jednamapoakce = new PodkladAction(ka);
-			akce.mapoakce.add(jednamapoakce);
-			bb.registerSigleton(jednamapoakce);
-
-		}
+        Stream.concat(
+            Stream.of(EKaType.values()),
+            Stream.empty() // sem přijdou konfigurovatelné mapové zdroje
+        )
+            .map(PodkladAction::new)
+            .forEach(jednamapoakce -> {
+                akce.mapoakce.add(jednamapoakce);
+                bb.registerSigleton(jednamapoakce);
+            });
 	}
 
 	public void setMainFrame(final JMainFrame frame) {

--- a/src/main/java/cz/geokuk/core/program/Inicializator.java
+++ b/src/main/java/cz/geokuk/core/program/Inicializator.java
@@ -29,7 +29,13 @@ import cz.geokuk.plugins.refbody.HlidacReferencnihoBodu;
 import cz.geokuk.plugins.refbody.RefbodyModel;
 import cz.geokuk.plugins.vylety.*;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
 
 /**
  * @author Martin Veverka
@@ -39,6 +45,7 @@ public class Inicializator {
 
 	private final MainFrameHolder mainFrameHolder = new MainFrameHolder();
 	private NapovedaModel napovedaModel;
+	private KesoidModel kesoidModel;
 
 	public void inicializace() {
 		final BeanBag bb = new BeanBag();
@@ -74,7 +81,7 @@ public class Inicializator {
 		bb.registerSigleton(new KachloDownloader());
 
 		bb.registerSigleton(new MapyModel());
-		bb.registerSigleton(new KesoidModel());
+		kesoidModel = bb.registerSigleton(new KesoidModel());
 
 		bb.registerSigleton(new HlidacReferencnihoBodu());
 		bb.registerSigleton(new ProfileModel());
@@ -106,10 +113,10 @@ public class Inicializator {
 	}
 
 	public void intMapAkce(final BeanBag bb, final Akce akce) {
-        Stream.concat(
-            Stream.of(EKaType.values()),
-            Stream.empty() // sem přijdou konfigurovatelné mapové zdroje
-        )
+		Stream.of(null
+			, asList(EKaType.values())
+			, Optional.ofNullable(kesoidModel).map(KesoidModel::getConfigurableMapSources).orElse(null)
+		).filter(Objects::nonNull).flatMap(Collection::stream)
             .map(PodkladAction::new)
             .forEach(jednamapoakce -> {
                 akce.mapoakce.add(jednamapoakce);

--- a/src/main/java/cz/geokuk/core/program/JMainFrame.java
+++ b/src/main/java/cz/geokuk/core/program/JMainFrame.java
@@ -1,14 +1,9 @@
 package cz.geokuk.core.program;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.swing.*;
-import javax.swing.border.EtchedBorder;
-
-import cz.geokuk.core.coord.*;
+import cz.geokuk.core.coord.JPozicovnikSlide;
+import cz.geokuk.core.coord.JSingleSlide0;
+import cz.geokuk.core.coord.JZoomovaciObdelnik;
+import cz.geokuk.core.coord.SlideListProvider;
 import cz.geokuk.core.render.JRenderSlide;
 import cz.geokuk.framework.*;
 import cz.geokuk.img.ImageLoader;
@@ -22,10 +17,19 @@ import cz.geokuk.plugins.kesoidkruhy.JZvyraznovaciKruhySlide;
 import cz.geokuk.plugins.kesoidobsazenost.JObsazenost;
 import cz.geokuk.plugins.kesoidpopisky.JPopiskySlide;
 import cz.geokuk.plugins.mapy.kachle.data.EKaType;
-import cz.geokuk.plugins.mapy.kachle.gui.*;
+import cz.geokuk.plugins.mapy.kachle.gui.JKachlovnik;
+import cz.geokuk.plugins.mapy.kachle.gui.JKachlovnikDoRohu;
+import cz.geokuk.plugins.mapy.kachle.gui.JKachlovnikPresCele;
 import cz.geokuk.plugins.mrizky.*;
 import cz.geokuk.util.gui.CornerLayoutManager;
 import cz.geokuk.util.gui.ERoh;
+
+import javax.swing.*;
+import javax.swing.border.EtchedBorder;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JMainFrame extends JFrame implements SlideListProvider {
 

--- a/src/main/java/cz/geokuk/core/program/JPrehledSouboru.java
+++ b/src/main/java/cz/geokuk/core/program/JPrehledSouboru.java
@@ -12,6 +12,7 @@ import cz.geokuk.framework.Dlg;
 import cz.geokuk.plugins.kesoid.mvc.*;
 import cz.geokuk.plugins.mapy.KachleUmisteniSouboru;
 import cz.geokuk.plugins.mapy.KachleUmisteniSouboruChangedEvent;
+import cz.geokuk.plugins.mapy.MapyModel;
 import cz.geokuk.plugins.mapy.kachle.KachleModel;
 import cz.geokuk.util.exception.FExceptionDumper;
 import cz.geokuk.util.file.Filex;
@@ -46,6 +47,8 @@ public class JPrehledSouboru extends JPanel {
 	private JTextField jGsakCasNalezu;
 	private JTextField jGsakCasNenalezu;
 
+	private JJedenSouborPanel jMapyJsonFile;
+
 	private JJedenSouborPanel jImageMyDir;
 	private JJedenSouborPanel jOziDir;
 	private JJedenSouborPanel jKmzDir;
@@ -57,6 +60,7 @@ public class JPrehledSouboru extends JPanel {
 	private KachleModel kachleModel;
 
 	private RenderModel renderModel;
+	private MapyModel mapyModel;
 
 	private JTabbedPane jTabbedPane;
 
@@ -85,6 +89,9 @@ public class JPrehledSouboru extends JPanel {
 	public void inject(final RenderModel renderModel) {
 		this.renderModel = renderModel;
 	}
+	public void inject(final MapyModel mapyModel) {
+		this.mapyModel = mapyModel;
+	}
 
 	public void onEvent(final KachleUmisteniSouboruChangedEvent event) {
 		final KachleUmisteniSouboru u = event.getUmisteniSouboru();
@@ -103,7 +110,10 @@ public class JPrehledSouboru extends JPanel {
 		jImage3rdPartyDir.setFilex(u.getImage3rdPartyDir());
 		jImageMyDir.setFilex(u.getImageMyDir());
 	}
-
+	public void onEvent(final MapyUmisteniSouboruChangedEvent event) {
+		final MapyUmisteniSouboru u = event.getUmisteniSouboru();
+		jMapyJsonFile.setFilex(u.getMapyJsonFile());
+	}
 	public void onEvent(final GsakParametryNacitaniChangedEvent event) {
 		final GsakParametryNacitani g = event.getGsakParametryNacitani();
 		jGsakCasNalezu.setText(_join(g.getCasNalezu()));
@@ -170,6 +180,14 @@ public class JPrehledSouboru extends JPanel {
 		                + "<br/>Pokud obsahuje kromě časového údaje i další text, bude použit jen časový údaj." //
 		                + "<br/>Můžete uvést více políček, použije se první časový údaj, který bude nalezen." //
 		                + "</html>");
+
+		jMapyJsonFile = pridejJednuPolozkuproEdit(null, tab1a, "Definice mapových podkladů.", false, false);
+//				"<html>" +
+//				" JSON soubor ve formátu používaném nástrojem Geocaching Maps Enhancements (GME)." +
+//				" Vlastní název soubor musí mít příponu .json." +
+//				" Očekává se, že této příponě předchází název kódování (znakové sady) použitého pro obsah souboru;" +
+//				" není-li kódování uvedeno, předpokládá se UTF-8." +
+//				"</html>"
 
 		jImage3rdPartyDir = pridejJednuPolozkuproEdit(null, tab2, "Složka s rozšiřujícími obrázky jiných geokolegů.", true, true);
 		jImageMyDir = pridejJednuPolozkuproEdit(null, tab2, "Složka s mými vlastními rozšiřujícími obrázky.", true, true);
@@ -292,6 +310,11 @@ public class JPrehledSouboru extends JPanel {
 					u3.setKmzDir(jKmzDir.vezmiSouborAProver());
 					u3.setPictureDir(jPictureDir.vezmiSouborAProver());
 					renderModel.setUmisteniSouboru(u3);
+				}
+				{
+					MapyUmisteniSouboru um = new MapyUmisteniSouboru();
+					um.setMapyJsonFile(jMapyJsonFile.vezmiSouborAProver());
+					mapyModel.setUmisteniSouboru(um);
 				}
 
 				// Board.multiNacitacLoaderManager.startLoad(true);

--- a/src/main/java/cz/geokuk/core/program/Menu.java
+++ b/src/main/java/cz/geokuk/core/program/Menu.java
@@ -2,6 +2,7 @@ package cz.geokuk.core.program;
 
 import java.awt.event.KeyEvent;
 import java.util.List;
+import java.util.Objects;
 
 import javax.swing.*;
 
@@ -10,6 +11,7 @@ import cz.geokuk.plugins.kesoid.kind.kes.*;
 import cz.geokuk.plugins.kesoid.mapicon.JMenuIkony;
 import cz.geokuk.plugins.kesoid.mvc.JVybiracVyletu;
 import cz.geokuk.plugins.mapy.MapyAction0;
+import cz.geokuk.plugins.mapy.MapyModel;
 import cz.geokuk.plugins.mapy.PodkladAction;
 import cz.geokuk.plugins.refbody.NaKonkretniBodAction;
 import cz.geokuk.plugins.refbody.RefbodyModel;
@@ -19,6 +21,7 @@ public class Menu extends MenuStrujce {
 
 	private Akce akce;
 	private RefbodyModel refbodyModel;
+	private MapyModel mapyModel;
 	private final JMainFrame jMainFrame;
 
 	public Menu(final JMainFrame jMainFrame, final JGeokukToolbar geokukToolbar) {
@@ -38,11 +41,16 @@ public class Menu extends MenuStrujce {
 		this.refbodyModel = refbodyModel;
 	}
 
-	public void makeMapSubmenuPart(final Akce akce) {
+	public void inject(MapyModel mapyModel) {
+		this.mapyModel = mapyModel;
+	}
+
+	public void makeMapSubmenuPart(final Akce akce, String selectedPodklad) {
 		final ButtonGroup mapPodkladButtonGroup = new ButtonGroup();
 		for (final MapyAction0 mapoakce1 : akce.mapoakce) {
 			if (mapoakce1 instanceof PodkladAction) {
-				item(mapoakce1, mapPodkladButtonGroup);
+				boolean selected = Objects.equals(selectedPodklad, ((PodkladAction)mapoakce1).getPodklad().getId());
+				item(mapoakce1, mapPodkladButtonGroup, selected);
 			}
 		}
 
@@ -108,7 +116,7 @@ public class Menu extends MenuStrujce {
 		menu("Mapy", "Řízení zobrazení součástí map");
 		menu.setMnemonic(KeyEvent.VK_M);
 
-		makeMapSubmenuPart(akce);
+		makeMapSubmenuPart(akce, mapyModel.getConfiguredPodklad());
 
 		separator();
 		item(akce.priblizMapuAction);

--- a/src/main/java/cz/geokuk/core/program/Menu.java
+++ b/src/main/java/cz/geokuk/core/program/Menu.java
@@ -53,9 +53,6 @@ public class Menu extends MenuStrujce {
 				item(mapoakce1, mapPodkladButtonGroup, selected);
 			}
 		}
-
-		separator();
-
 	}
 
 	@Override

--- a/src/main/java/cz/geokuk/core/render/JNastavovacVelikostiDlazdic.java
+++ b/src/main/java/cz/geokuk/core/render/JNastavovacVelikostiDlazdic.java
@@ -5,7 +5,7 @@ import javax.swing.event.ChangeListener;
 
 import cz.geokuk.framework.AfterEventReceiverRegistrationInit;
 import cz.geokuk.plugins.mapy.ZmenaMapNastalaEvent;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 
 public class JNastavovacVelikostiDlazdic extends JPanel implements AfterEventReceiverRegistrationInit {
 
@@ -32,7 +32,7 @@ public class JNastavovacVelikostiDlazdic extends JPanel implements AfterEventRec
 	}
 
 	/**
-	 * @return
+	; * @return
 	 */
 	public Integer getMaximalniVelikost() {
 		return (Integer) iModel.getValue();
@@ -53,7 +53,7 @@ public class JNastavovacVelikostiDlazdic extends JPanel implements AfterEventRec
 	}
 
 	public void onEvent(final ZmenaMapNastalaEvent event) {
-		final EKaType podklad = event.getKatype();
+		final KaType podklad = event.getKatype();
 		iModel.setMinimum(podklad.getMinMoumer());
 		iModel.setMaximum(podklad.getMaxMoumer());
 		iModel.setValue(podklad.fitMoumer((Integer) iModel.getValue()));

--- a/src/main/java/cz/geokuk/core/render/JNastavovecMeritka.java
+++ b/src/main/java/cz/geokuk/core/render/JNastavovecMeritka.java
@@ -7,7 +7,7 @@ import javax.swing.SpinnerNumberModel;
 
 import cz.geokuk.framework.AfterEventReceiverRegistrationInit;
 import cz.geokuk.plugins.mapy.ZmenaMapNastalaEvent;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 
 public class JNastavovecMeritka extends JSpinner implements AfterEventReceiverRegistrationInit {
 
@@ -49,7 +49,7 @@ public class JNastavovecMeritka extends JSpinner implements AfterEventReceiverRe
 	}
 
 	public void onEvent(final ZmenaMapNastalaEvent event) {
-		final EKaType podklad = event.getKatype();
+		final KaType podklad = event.getKatype();
 		iModel.setMinimum(podklad.getMinMoumer());
 		iModel.setMaximum(podklad.getMaxMoumer());
 		iModel.setValue(podklad.fitMoumer((Integer) iModel.getValue()));

--- a/src/main/java/cz/geokuk/core/render/JRenderNahledKachlovnik.java
+++ b/src/main/java/cz/geokuk/core/render/JRenderNahledKachlovnik.java
@@ -1,6 +1,6 @@
 package cz.geokuk.core.render;
 
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 import cz.geokuk.plugins.mapy.kachle.gui.JKachlovnik;
 import cz.geokuk.plugins.mapy.kachle.podklady.Priority;
 
@@ -13,7 +13,7 @@ public class JRenderNahledKachlovnik extends JKachlovnik {
 	}
 
 	@Override
-	public void setKachloType(final EKaType katype) {
+	public void setKachloType(final KaType katype) {
 		super.setKachloType(katype);
 	}
 

--- a/src/main/java/cz/geokuk/core/render/RenderModel.java
+++ b/src/main/java/cz/geokuk/core/render/RenderModel.java
@@ -13,7 +13,7 @@ import cz.geokuk.core.coordinates.Wgs;
 import cz.geokuk.core.program.FPref;
 import cz.geokuk.framework.*;
 import cz.geokuk.plugins.mapy.ZmenaMapNastalaEvent;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 import cz.geokuk.util.file.Filex;
 
 public class RenderModel extends Model0 {
@@ -246,7 +246,7 @@ public class RenderModel extends Model0 {
 	}
 
 	public void onEvent(final ZmenaMapNastalaEvent event) {
-		final EKaType podklad = event.getKatype();
+		final KaType podklad = event.getKatype();
 		final RenderSettings rs = renderSettings.copy();
 		rs.setRenderedMoumer(podklad.fitMoumer(rs.getRenderedMoumer()));
 		setRenderSettings(rs);

--- a/src/main/java/cz/geokuk/framework/PodkladMapSpecificModel0.java
+++ b/src/main/java/cz/geokuk/framework/PodkladMapSpecificModel0.java
@@ -96,7 +96,7 @@ public abstract class PodkladMapSpecificModel0<T extends Model0, S extends Copya
 	 * @return
 	 */
 	private String jmenoPodkladu(final KaType podklad) {
-		return podklad == null ? "bezmap" : podklad.toString();
+		return podklad == null ? "bezmap" : podklad.getId();
 	}
 
 	/**

--- a/src/main/java/cz/geokuk/framework/PodkladMapSpecificModel0.java
+++ b/src/main/java/cz/geokuk/framework/PodkladMapSpecificModel0.java
@@ -1,7 +1,7 @@
 package cz.geokuk.framework;
 
 import cz.geokuk.plugins.mapy.ZmenaMapNastalaEvent;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 
 public abstract class PodkladMapSpecificModel0<T extends Model0, S extends Copyable<S>> extends Model0 {
 
@@ -9,7 +9,7 @@ public abstract class PodkladMapSpecificModel0<T extends Model0, S extends Copya
 	 *
 	 */
 	protected MyPreferences prefNode;
-	private EKaType podkladMap;
+	private KaType podkladMap;
 
 	private S structure;
 
@@ -29,7 +29,7 @@ public abstract class PodkladMapSpecificModel0<T extends Model0, S extends Copya
 	}
 
 	public void onEvent(final ZmenaMapNastalaEvent event) {
-		final EKaType podklad = event.getKatype();
+		final KaType podklad = event.getKatype();
 		setPodkladMap(podklad);
 	}
 
@@ -45,7 +45,7 @@ public abstract class PodkladMapSpecificModel0<T extends Model0, S extends Copya
 	/**
 	 * @param podklad
 	 */
-	public void setPodkladMap(final EKaType podklad) {
+	public void setPodkladMap(final KaType podklad) {
 		if (podkladMap == podklad) {
 			return;
 		}
@@ -95,14 +95,14 @@ public abstract class PodkladMapSpecificModel0<T extends Model0, S extends Copya
 	 * @param podklad
 	 * @return
 	 */
-	private String jmenoPodkladu(final EKaType podklad) {
-		return podklad == null ? "bezmap" : podklad.name();
+	private String jmenoPodkladu(final KaType podklad) {
+		return podklad == null ? "bezmap" : podklad.toString();
 	}
 
 	/**
 	 * @return
 	 */
-	private S load(final EKaType podklad) {
+	private S load(final KaType podklad) {
 		final S p = prefNode.getStructure(jmenoPodkladu(podklad), createDefaults());
 		return p;
 	}
@@ -110,7 +110,7 @@ public abstract class PodkladMapSpecificModel0<T extends Model0, S extends Copya
 	/**
 	 * @param p
 	 */
-	private void save(final EKaType podklad, final S p) {
+	private void save(final KaType podklad, final S p) {
 		prefNode.putStructure(jmenoPodkladu(podklad), p);
 	}
 

--- a/src/main/java/cz/geokuk/plugins/kesoid/mvc/ConfigurableMapSourcesChangedEvent.java
+++ b/src/main/java/cz/geokuk/plugins/kesoid/mvc/ConfigurableMapSourcesChangedEvent.java
@@ -1,0 +1,21 @@
+package cz.geokuk.plugins.kesoid.mvc;
+
+import cz.geokuk.framework.Event0;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
+
+import java.util.Collection;
+
+public class ConfigurableMapSourcesChangedEvent extends Event0<KesoidModel> {
+
+    private final Collection<KaType> iConfigurableMapSources;
+
+    public ConfigurableMapSourcesChangedEvent(final Collection<KaType> aConfigurableMapSources) {
+        super();
+        iConfigurableMapSources = aConfigurableMapSources;
+    }
+
+    public Collection<KaType> getConfigurableMapSources() {
+        return iConfigurableMapSources;
+    }
+
+}

--- a/src/main/java/cz/geokuk/plugins/kesoid/mvc/KesoidModel.java
+++ b/src/main/java/cz/geokuk/plugins/kesoid/mvc/KesoidModel.java
@@ -45,7 +45,6 @@ public class KesoidModel extends Model0 {
 	private KesoidUmisteniSouboru umisteniSouboru;
 	private Set<File> blokovaneZdroje;
 	private GsakParametryNacitani gsakParametryNacitani;
-	private Collection<KaType> configurableMapSources;
 
 	// injektovanci
 	private final MultiNacitacLoaderManager multiNacitacLoaderManager = new MultiNacitacLoaderManager(this);
@@ -100,10 +99,6 @@ public class KesoidModel extends Model0 {
 
 	public GsakParametryNacitani getGsakParametryNacitani() {
 		return gsakParametryNacitani;
-	}
-
-	public Collection<KaType> getConfigurableMapSources() {
-		return configurableMapSources;
 	}
 
 	public void inject(final KesoidFilterModel filter) {
@@ -268,15 +263,6 @@ public class KesoidModel extends Model0 {
 		fire(new GsakParametryNacitaniChangedEvent(gsakParametryNacitani));
 	}
 
-	public void setConfigurableMapSources(final Collection<KaType> aConfigurableMapSources) {
-		configurableMapSources = aConfigurableMapSources;
-//		final MyPreferences pref = currPrefe().node(FPref.GSAK_node);
-//		pref.putStringSet(FPref.GSAK_CAS_NALEZU_value, aGsakParametryNacitani.getCasNalezu());
-//		pref.putStringSet(FPref.GSAK_CAS_NENALEZU_value, aGsakParametryNacitani.getCasNenalezu());
-//		pref.putBoolean(FPref.GSAK_NACITAT_VSECHNO, aGsakParametryNacitani.isNacistVsechnyDatabaze());
-		fire(new ConfigurableMapSourcesChangedEvent(configurableMapSources));
-	}
-
 	/**
 	 * @param aUmisteniSouboru
 	 *            the umisteniSouboru to set
@@ -376,7 +362,6 @@ public class KesoidModel extends Model0 {
 		// fire(new GccomNickChangedEvent(gccomNick));
 		// loadUmisteniSouboru();
 		setGsakParametryNacitani(loadGsakParametryNacitani());
-		setConfigurableMapSources(loadConfigurableMapSources());
 		setUmisteniSouboru(loadUmisteniSouboru());
 
 		setOnoff(currPrefe().node(FPref.KESOID_node).getBoolean(FPref.KESOID_VISIBLE_value, true));
@@ -409,28 +394,6 @@ public class KesoidModel extends Model0 {
 		g.setCasNenalezu(pref.getStringList(FPref.GSAK_CAS_NENALEZU_value, Arrays.asList("UserData")));
 		g.setNacistVsechnyDatabaze(pref.getBoolean(FPref.GSAK_NACITAT_VSECHNO, true));
 		return g;
-	}
-
-	private Collection<KaType> loadConfigurableMapSources() {
-		return asList(
-			KaType.simpleKaType( 0, 18, "osm",           "OSM", 				0, null, new ConfigurableMapUrlBuilder("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", "abc")),
-			KaType.simpleKaType( 0, 18, "ocmde",         "OSM German Style", 	0, null, new ConfigurableMapUrlBuilder("http://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png")),
-			KaType.simpleKaType( 0, 18, "ocm",           "OpenCycleMap", 		0, null, new ConfigurableMapUrlBuilder("https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")),
-			KaType.simpleKaType( 0, 22, "googlemaps",    "Google Maps", 		0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?&x={x}&y={y}&z={z}", "1234", 256)),
-			KaType.simpleKaType( 0, 22, "googlemapssat", "Google Satellite", 	0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?lyrs=s&x={x}&y={y}&z={z}", "1234", 256)),
-			KaType.simpleKaType( 0, 20, "googlehybr",    "Google Maps Hybrid",  0, null, new ConfigurableMapUrlBuilder("http://mt0.google.com/vt/lyrs=s,m@110&hl=en&x={x}&y={y}&z={z}", 256)),
-			KaType.simpleKaType( 1, 20, "bingmap",       "Bing Maps", 		    0, null, new ConfigurableMapUrlBuilder("https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&mkt=en-gb&lbl=l1&stl=h&shading=hill&n=z", "0123")),
-			KaType.simpleKaType( 0, 18, "esriimagy",     "Esri WorldImagery",   0, null, new ConfigurableMapUrlBuilder("http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}")),
-			KaType.simpleKaType( 0, 18, "esriworld",     "Esri WorldStreetMap", 0, null, new ConfigurableMapUrlBuilder("http://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}")),
-			KaType.simpleKaType( 0, 18, "esritopo",      "Esri WorldTopoMap",   0, null, new ConfigurableMapUrlBuilder("http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}")),
-			KaType.simpleKaType(14, 17, "binglondon",    "London Street Maps",  0, null, new ConfigurableMapUrlBuilder("https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&productSet=mmCB", "0123")),
-			KaType.simpleKaType( 1, 18, "nazev",         "MTBmap.cz",           0, null, new ConfigurableMapUrlBuilder("http://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png")),
-			KaType.simpleKaType(10, 19, "cuzktop",       "ČUZK - Topografická", 0, null, new ConfigurableMapUrlBuilder("http://ags.cuzk.cz/arcgis/services/zmwm/MapServer/WMSServer")),
-			KaType.simpleKaType(10, 20, "cuzksat",       "ČUZK - Satelitní", 	0, null, new ConfigurableMapUrlBuilder("http://ags.cuzk.cz/arcgis/services/ortofoto_wm/MapServer/WMSServer")),
-			KaType.simpleKaType(10, 20, "cuzkater",      "ČUZK - Jen terén", 	0, null, new ConfigurableMapUrlBuilder("http://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer\",\"crs\":\"EPSG:4326\",\"layers\":\"dmr5g:GrayscaleHillshade")),
-			KaType.simpleKaType(10, 20, "cuzklidar",     "ČUZK - LIDAR", 		0, null, new ConfigurableMapUrlBuilder("http://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer")),
-			KaType.simpleKaType( 0, 22, "googlelabels",  "Google labels", 	    0, null, new ConfigurableMapUrlBuilder("http://mt1.google.com/vt/lyrs=h@218000000&hl=en&src=app&x={x}&y={y}&z={z}&s="))
-		);
 	}
 
 	private void startKesLoading() {

--- a/src/main/java/cz/geokuk/plugins/kesoid/mvc/KesoidModel.java
+++ b/src/main/java/cz/geokuk/plugins/kesoid/mvc/KesoidModel.java
@@ -17,11 +17,15 @@ import cz.geokuk.plugins.kesoid.importek.InformaceOZdrojich;
 import cz.geokuk.plugins.kesoid.importek.MultiNacitacLoaderManager;
 import cz.geokuk.plugins.kesoid.kind.KesoidPluginManager;
 import cz.geokuk.plugins.kesoid.mapicon.*;
+import cz.geokuk.plugins.mapy.kachle.data.ConfigurableMapUrlBuilder;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 import cz.geokuk.plugins.vylety.EVylet;
 import cz.geokuk.util.exception.EExceptionSeverity;
 import cz.geokuk.util.exception.FExceptionDumper;
 import cz.geokuk.util.file.KeFile;
 import lombok.Getter;
+
+import static java.util.Arrays.asList;
 
 /**
  * @author Martin Veverka
@@ -41,6 +45,7 @@ public class KesoidModel extends Model0 {
 	private KesoidUmisteniSouboru umisteniSouboru;
 	private Set<File> blokovaneZdroje;
 	private GsakParametryNacitani gsakParametryNacitani;
+	private Collection<KaType> configurableMapSources;
 
 	// injektovanci
 	private final MultiNacitacLoaderManager multiNacitacLoaderManager = new MultiNacitacLoaderManager(this);
@@ -95,6 +100,10 @@ public class KesoidModel extends Model0 {
 
 	public GsakParametryNacitani getGsakParametryNacitani() {
 		return gsakParametryNacitani;
+	}
+
+	public Collection<KaType> getConfigurableMapSources() {
+		return configurableMapSources;
 	}
 
 	public void inject(final KesoidFilterModel filter) {
@@ -259,6 +268,15 @@ public class KesoidModel extends Model0 {
 		fire(new GsakParametryNacitaniChangedEvent(gsakParametryNacitani));
 	}
 
+	public void setConfigurableMapSources(final Collection<KaType> aConfigurableMapSources) {
+		configurableMapSources = aConfigurableMapSources;
+//		final MyPreferences pref = currPrefe().node(FPref.GSAK_node);
+//		pref.putStringSet(FPref.GSAK_CAS_NALEZU_value, aGsakParametryNacitani.getCasNalezu());
+//		pref.putStringSet(FPref.GSAK_CAS_NENALEZU_value, aGsakParametryNacitani.getCasNenalezu());
+//		pref.putBoolean(FPref.GSAK_NACITAT_VSECHNO, aGsakParametryNacitani.isNacistVsechnyDatabaze());
+		fire(new ConfigurableMapSourcesChangedEvent(configurableMapSources));
+	}
+
 	/**
 	 * @param aUmisteniSouboru
 	 *            the umisteniSouboru to set
@@ -358,6 +376,7 @@ public class KesoidModel extends Model0 {
 		// fire(new GccomNickChangedEvent(gccomNick));
 		// loadUmisteniSouboru();
 		setGsakParametryNacitani(loadGsakParametryNacitani());
+		setConfigurableMapSources(loadConfigurableMapSources());
 		setUmisteniSouboru(loadUmisteniSouboru());
 
 		setOnoff(currPrefe().node(FPref.KESOID_node).getBoolean(FPref.KESOID_VISIBLE_value, true));
@@ -390,6 +409,28 @@ public class KesoidModel extends Model0 {
 		g.setCasNenalezu(pref.getStringList(FPref.GSAK_CAS_NENALEZU_value, Arrays.asList("UserData")));
 		g.setNacistVsechnyDatabaze(pref.getBoolean(FPref.GSAK_NACITAT_VSECHNO, true));
 		return g;
+	}
+
+	private Collection<KaType> loadConfigurableMapSources() {
+		return asList(
+			KaType.simpleKaType( 0, 18, "osm",           "OSM", 				0, null, new ConfigurableMapUrlBuilder("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", "abc")),
+			KaType.simpleKaType( 0, 18, "ocmde",         "OSM German Style", 	0, null, new ConfigurableMapUrlBuilder("http://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png")),
+			KaType.simpleKaType( 0, 18, "ocm",           "OpenCycleMap", 		0, null, new ConfigurableMapUrlBuilder("https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")),
+			KaType.simpleKaType( 0, 22, "googlemaps",    "Google Maps", 		0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?&x={x}&y={y}&z={z}", "1234", 256)),
+			KaType.simpleKaType( 0, 22, "googlemapssat", "Google Satellite", 	0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?lyrs=s&x={x}&y={y}&z={z}", "1234", 256)),
+			KaType.simpleKaType( 0, 20, "googlehybr",    "Google Maps Hybrid",  0, null, new ConfigurableMapUrlBuilder("http://mt0.google.com/vt/lyrs=s,m@110&hl=en&x={x}&y={y}&z={z}", 256)),
+			KaType.simpleKaType( 1, 20, "bingmap",       "Bing Maps", 		    0, null, new ConfigurableMapUrlBuilder("https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&mkt=en-gb&lbl=l1&stl=h&shading=hill&n=z", "0123")),
+			KaType.simpleKaType( 0, 18, "esriimagy",     "Esri WorldImagery",   0, null, new ConfigurableMapUrlBuilder("http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}")),
+			KaType.simpleKaType( 0, 18, "esriworld",     "Esri WorldStreetMap", 0, null, new ConfigurableMapUrlBuilder("http://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}")),
+			KaType.simpleKaType( 0, 18, "esritopo",      "Esri WorldTopoMap",   0, null, new ConfigurableMapUrlBuilder("http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}")),
+			KaType.simpleKaType(14, 17, "binglondon",    "London Street Maps",  0, null, new ConfigurableMapUrlBuilder("https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&productSet=mmCB", "0123")),
+			KaType.simpleKaType( 1, 18, "nazev",         "MTBmap.cz",           0, null, new ConfigurableMapUrlBuilder("http://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png")),
+			KaType.simpleKaType(10, 19, "cuzktop",       "ČUZK - Topografická", 0, null, new ConfigurableMapUrlBuilder("http://ags.cuzk.cz/arcgis/services/zmwm/MapServer/WMSServer")),
+			KaType.simpleKaType(10, 20, "cuzksat",       "ČUZK - Satelitní", 	0, null, new ConfigurableMapUrlBuilder("http://ags.cuzk.cz/arcgis/services/ortofoto_wm/MapServer/WMSServer")),
+			KaType.simpleKaType(10, 20, "cuzkater",      "ČUZK - Jen terén", 	0, null, new ConfigurableMapUrlBuilder("http://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer\",\"crs\":\"EPSG:4326\",\"layers\":\"dmr5g:GrayscaleHillshade")),
+			KaType.simpleKaType(10, 20, "cuzklidar",     "ČUZK - LIDAR", 		0, null, new ConfigurableMapUrlBuilder("http://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer")),
+			KaType.simpleKaType( 0, 22, "googlelabels",  "Google labels", 	    0, null, new ConfigurableMapUrlBuilder("http://mt1.google.com/vt/lyrs=h@218000000&hl=en&src=app&x={x}&y={y}&z={z}&s="))
+		);
 	}
 
 	private void startKesLoading() {

--- a/src/main/java/cz/geokuk/plugins/kesoid/mvc/MapyUmisteniSouboru.java
+++ b/src/main/java/cz/geokuk/plugins/kesoid/mvc/MapyUmisteniSouboru.java
@@ -1,0 +1,57 @@
+package cz.geokuk.plugins.kesoid.mvc;
+
+import cz.geokuk.core.program.FConst;
+import cz.geokuk.core.program.UmisteniSouboru0;
+import cz.geokuk.util.file.Filex;
+
+import java.io.File;
+import java.util.Objects;
+
+public class MapyUmisteniSouboru extends UmisteniSouboru0 {
+	public static final Filex MAPY_JSON_FILE = new Filex(new File(FConst.HOME_DIR, "geokuk/map-definitions.utf-8.json"), false, true);
+
+	private Filex mapyJsonFile;
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final MapyUmisteniSouboru that = (MapyUmisteniSouboru) o;
+		return equalsDataLocations(that);
+	}
+
+	/** Porovná, zda se shodují umístění datových složek. */
+	public boolean equalsDataLocations(final MapyUmisteniSouboru that) {
+		if (!Objects.equals(mapyJsonFile, that == null ? null : that.mapyJsonFile)) {
+			return false;
+		}
+		return true;
+	}
+
+	public Filex getMapyJsonFile() {
+		check(mapyJsonFile);
+		return mapyJsonFile;
+	}
+
+	public void setMapyJsonFile(Filex mapyJsonFile) {
+		this.mapyJsonFile = mapyJsonFile;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (mapyJsonFile == null ? 0 : mapyJsonFile.hashCode());
+		return result;
+	}
+
+	private void check(final Filex file) {
+		if (file == null) {
+			throw new RuntimeException("Jmena souboru jeste nebyla inicializovana.");
+		}
+	}
+}

--- a/src/main/java/cz/geokuk/plugins/kesoid/mvc/MapyUmisteniSouboruChangedEvent.java
+++ b/src/main/java/cz/geokuk/plugins/kesoid/mvc/MapyUmisteniSouboruChangedEvent.java
@@ -1,0 +1,17 @@
+package cz.geokuk.plugins.kesoid.mvc;
+
+import cz.geokuk.framework.Event0;
+
+public class MapyUmisteniSouboruChangedEvent extends Event0<KesoidModel> {
+
+	private final MapyUmisteniSouboru umisteniSouboru;
+
+	public MapyUmisteniSouboruChangedEvent(final MapyUmisteniSouboru umisteniSouboru) {
+		super();
+		this.umisteniSouboru = umisteniSouboru;
+	}
+	public MapyUmisteniSouboru getUmisteniSouboru() {
+		return umisteniSouboru;
+	}
+
+}

--- a/src/main/java/cz/geokuk/plugins/kesoidkruhy/JZvyraznovaciKruhySlide.java
+++ b/src/main/java/cz/geokuk/plugins/kesoidkruhy/JZvyraznovaciKruhySlide.java
@@ -8,7 +8,7 @@ import cz.geokuk.core.program.FConst;
 import cz.geokuk.plugins.kesoid.Wpt;
 import cz.geokuk.plugins.kesoid.mvc.KeskyVyfiltrovanyEvent;
 import cz.geokuk.plugins.mapy.ZmenaMapNastalaEvent;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 import cz.geokuk.util.index2d.Indexator;
 
 public class JZvyraznovaciKruhySlide extends JSingleSlide0 {
@@ -17,7 +17,7 @@ public class JZvyraznovaciKruhySlide extends JSingleSlide0 {
 
 	private Indexator<Wpt> iIndexator;
 
-	private EKaType podklad;
+	private KaType podklad;
 	private KruhySettings kruhy;
 
 	public JZvyraznovaciKruhySlide() {

--- a/src/main/java/cz/geokuk/plugins/mapy/MapyAction0.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/MapyAction0.java
@@ -1,15 +1,15 @@
 package cz.geokuk.plugins.mapy;
 
 import cz.geokuk.framework.ToggleAction0;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 
 public abstract class MapyAction0 extends ToggleAction0 {
 
 	private static final long serialVersionUID = 8106696486908484270L;
 	private MapyModel mapyModel;
-	private final EKaType katype;
+	private final KaType katype;
 
-	public MapyAction0(final EKaType katype) {
+	public MapyAction0(final KaType katype) {
 		super(katype.getNazev());
 		this.katype = katype;
 		putValue(SHORT_DESCRIPTION, katype.getPopis());
@@ -29,7 +29,7 @@ public abstract class MapyAction0 extends ToggleAction0 {
 		this.mapyModel = mapyModel;
 	}
 
-	protected EKaType getKaType() {
+	protected KaType getKaType() {
 		return katype;
 	}
 

--- a/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
@@ -1,5 +1,6 @@
 package cz.geokuk.plugins.mapy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.geokuk.core.program.FPref;
 import cz.geokuk.framework.Model0;
 import cz.geokuk.plugins.mapy.kachle.data.ConfigurableMapUrlBuilder;
@@ -93,5 +94,237 @@ public class MapyModel extends Model0 {
                 KaType.simpleKaType("cuzklidar",    "ČUZK - LIDAR",        10, 20, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer")),
                 KaType.simpleKaType("googlelabels", "Google labels",        5, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt1.google.com/vt/lyrs=h@218000000&hl=en&src=app&x={x}&y={y}&z={z}&s="))
         );
+    }
+
+    public List<Map<String, Object>> loadMapDefinitions() {
+        try {
+            return new ObjectMapper().readValue(_mapDefinitionsJson(), List.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Stream<KaType> mapToKaType(List<Map<String, Object>> definitions) {
+        return definitions.stream().map(this::mapToKaType);
+    }
+
+    private KaType mapToKaType(Map<String, Object> definition) {
+        ConfiguredKaType result = new ConfiguredKaType();
+        definition.forEach((key, value) -> {
+            Class<?> expectedType = null;
+            switch (key) {
+                case "name":
+                    if (value instanceof String) {
+                        result.setName((String) value);
+                    } else {
+                        expectedType = String.class;
+                    }
+                    break;
+                case "ignore":
+                    if (value instanceof Boolean) {
+                        result.setIgnore((Boolean) value);
+                    } else {
+                        expectedType = Boolean.class;
+                    }
+                    break;
+                case "transparent":
+                    if (value instanceof Boolean) {
+                        result.setTransparent((Boolean) value);
+                    } else {
+                        expectedType = Boolean.class;
+                    }
+                    break;
+                case "overlay":
+                    if (value instanceof Boolean) {
+                        result.setOverlay((Boolean) value);
+                    } else {
+                        expectedType = Boolean.class;
+                    }
+                    break;
+                case "alt":
+                    if (value instanceof String) {
+                        result.setAlt((String) value);
+                    } else {
+                        expectedType = String.class;
+                    }
+                    break;
+                case "tileUrl":
+                    if (value instanceof String) {
+                        result.setTileUrl((String) value);
+                    } else {
+                        expectedType = String.class;
+                    }
+                    break;
+                case "subdomains":
+                    if (value instanceof String) {
+                        result.setSubdomains((String) value);
+                    } else {
+                        expectedType = String.class;
+                    }
+                    break;
+                case "attribution":
+                    if (value instanceof String) {
+                        result.setAttribution((String) value);
+                    } else {
+                        expectedType = String.class;
+                    }
+                    break;
+                case "minZoom":
+                    if (value instanceof Number) {
+                        result.setMinZoom(((Number) value).intValue());
+                    } else {
+                        expectedType = Integer.class;
+                    }
+                    break;
+                case "maxZoom":
+                    if (value instanceof Number) {
+                        result.setMaxZoom(((Number) value).intValue());
+                    } else {
+                        expectedType = Integer.class;
+                    }
+                    break;
+                case "tileSize":
+                    if (value instanceof Number) {
+                        result.setTileSize(((Number) value).intValue());
+                    } else {
+                        expectedType = Integer.class;
+                    }
+                    break;
+                case "format":
+                case "crs":
+                case "layers":
+                    if (!(value instanceof String)) {
+                        expectedType = String.class;
+                    }
+                    // Používáno mapami od ČÚZK, zatím není podporováno.
+                    result.setIgnore(true);
+                    result.setUnsupported(true);
+                    break;
+                default:
+                    LOG.warn("Neznámý atribut \"{}\" v definici mapy.", key);
+                    break;
+            }
+            if (expectedType != null) {
+                LOG.error("Atribut \"{}\" definice mapy má být typu {}, ale je {}. Hodnota \"{}\" bude ignorována."
+                        , key, expectedType.getSimpleName(), value.getClass().getSimpleName(), value
+                );
+            }
+        });
+        return result;
+    }
+}
+
+class ConfiguredKaType implements KaType {
+    private static int DEFAULT_MIN_ZOOM = 5;
+    private static int DEFAULT_MAX_ZOOM = 20;
+    private static int DEFAULT_TILE_SIZE = 256;
+    private static boolean DEFAULT_IS_IGNORED = false;
+    private static boolean DEFAULT_IS_TRANSPARENT = false;
+    private static boolean DEFAULT_IS_OVERLAY = false;
+    private static boolean DEFAULT_IS_UNSUPPORTED = false;
+
+    private String name;
+    private String alt;
+    private String description;
+    private String attribution;
+    private int minZoom = DEFAULT_MIN_ZOOM;
+    private int maxZoom = DEFAULT_MAX_ZOOM;
+    private int tileSize = DEFAULT_TILE_SIZE;
+    private String tileUrl;
+    private String subdomains;
+    private int klavesa;
+    private KeyStroke keyStroke;
+    private boolean ignore = DEFAULT_IS_IGNORED;
+    private boolean transparent = DEFAULT_IS_TRANSPARENT;
+    private boolean overlay = DEFAULT_IS_OVERLAY;
+    private boolean unsupported = DEFAULT_IS_UNSUPPORTED;
+
+    void setName(String value) {
+        name = value;
+    }
+    void setAlt(String value) {
+        alt = value;
+    }
+    void setDescription(String value) {
+        description = value;
+    }
+    void setAttribution(String value) {
+        attribution = value;
+    }
+    void setMinZoom(int value) {
+        minZoom = value;
+    }
+    void setMaxZoom(int value) {
+        maxZoom = value;
+    }
+    void setTileSize(int value) {
+        tileSize = value;
+    }
+    void setTileUrl(String value) {
+        tileUrl = value;
+    }
+    void setSubdomains(String value) {
+        subdomains = value;
+    }
+    void setKlavesa(int value) {
+        klavesa = value;
+    }
+    void setKeyStroke(KeyStroke value) {
+        keyStroke = value;
+    }
+    void setIgnore(boolean value) {
+        ignore = value;
+    }
+    void setTransparent(boolean value) {
+        transparent = value;
+    }
+    void setOverlay(boolean value) {
+        overlay = value;
+    }
+    void setUnsupported(boolean value) {
+        unsupported = value;
+    }
+
+    @Override public int getMinMoumer() {
+        return minZoom;
+    }
+    @Override public int getMaxMoumer() {
+        return maxZoom;
+    }
+    @Override public int getMaxAutoMoumer() {
+        return maxZoom;
+    }
+    @Override public String getId() {
+        return name;
+    }
+    @Override public String getNazev() {
+        return alt;
+    }
+    @Override public String getPopis() {
+        return description;
+    }
+    public String getAttribution() {
+        return attribution;
+    }
+    @Override public int getKlavesa() {
+        return klavesa;
+    }
+    @Override public KeyStroke getKeyStroke() {
+        return keyStroke;
+    }
+    @Override public ConfigurableMapUrlBuilder getUrlBuilder() {
+        return new ConfigurableMapUrlBuilder(tileUrl, subdomains, tileSize);
+    }
+    @Override public boolean isIgnored() {
+        return ignore;
+    }
+    @Override public boolean isTransparent() {
+        return transparent;
+    }
+    @Override public boolean isOverleay() {
+        return overlay;
+    }
+    public boolean isUnsupported() {
+        return unsupported;
     }
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
@@ -75,23 +75,23 @@ public class MapyModel extends Model0 {
     }
     private Stream<KaType> _configurableMapSources() {
         return Stream.of(
-                KaType.simpleKaType("osm", 			"OSM",                  0, 18, 0, null, new ConfigurableMapUrlBuilder("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", "abc")),
-                KaType.simpleKaType("ocmde", 		"OSM German Style",     0, 18, 0, null, new ConfigurableMapUrlBuilder("https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png")),
-                KaType.simpleKaType("ocm", 			"OpenCycleMap",         0, 18, 0, null, new ConfigurableMapUrlBuilder("https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")),
-                KaType.simpleKaType("googlemaps", 	"Google Maps",          0, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?&x={x}&y={y}&z={z}", "1234", 256)),
-                KaType.simpleKaType("googlemapssat", "Google Satellite",    0, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?lyrs=s&x={x}&y={y}&z={z}", "1234", 256)),
-                KaType.simpleKaType("googlehybr", 	"Google Maps Hybrid",   0, 20, 0, null, new ConfigurableMapUrlBuilder("https://mt0.google.com/vt/lyrs=s,m@110&hl=en&x={x}&y={y}&z={z}", 256)),
+                KaType.simpleKaType("osm", 			"OSM",                  5, 18, 0, null, new ConfigurableMapUrlBuilder("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", "abc")),
+                KaType.simpleKaType("ocmde", 		"OSM German Style",     5, 18, 0, null, new ConfigurableMapUrlBuilder("https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png")),
+                KaType.simpleKaType("ocm", 			"OpenCycleMap",         5, 18, 0, null, new ConfigurableMapUrlBuilder("https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")),
+                KaType.simpleKaType("googlemaps", 	"Google Maps",          5, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?&x={x}&y={y}&z={z}", "1234", 256)),
+                KaType.simpleKaType("googlemapssat", "Google Satellite",    5, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?lyrs=s&x={x}&y={y}&z={z}", "1234", 256)),
+                KaType.simpleKaType("googlehybr", 	"Google Maps Hybrid",   5, 20, 0, null, new ConfigurableMapUrlBuilder("https://mt0.google.com/vt/lyrs=s,m@110&hl=en&x={x}&y={y}&z={z}", 256)),
                 KaType.simpleKaType("bingmap", 		"Bing Maps", 			1, 20, 0, null, new ConfigurableMapUrlBuilder("https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&mkt=en-gb&lbl=l1&stl=h&shading=hill&n=z", "0123")),
-                KaType.simpleKaType("esriimagy", 	"Esri WorldImagery", 	0, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}")),
-                KaType.simpleKaType("esriworld", 	"Esri WorldStreetMap", 	0, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}")),
-                KaType.simpleKaType("esritopo",     "Esri WorldTopoMap", 	0, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}")),
+                KaType.simpleKaType("esriimagy", 	"Esri WorldImagery", 	5, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}")),
+                KaType.simpleKaType("esriworld", 	"Esri WorldStreetMap", 	5, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}")),
+                KaType.simpleKaType("esritopo",     "Esri WorldTopoMap", 	5, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}")),
                 KaType.simpleKaType("binglondon",   "London Street Maps",  14, 17, 0, null, new ConfigurableMapUrlBuilder("https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&productSet=mmCB", "0123")),
                 KaType.simpleKaType("nazev",        "MTBmap.cz", 			1, 18, 0, null, new ConfigurableMapUrlBuilder("https://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png")),
                 KaType.simpleKaType("cuzktop",      "ČUZK - Topografická", 10, 19, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis/services/zmwm/MapServer/WMSServer")),
                 KaType.simpleKaType("cuzksat",      "ČUZK - Satelitní",    10, 20, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis/services/ortofoto_wm/MapServer/WMSServer")),
                 KaType.simpleKaType("cuzkater",     "ČUZK - Jen terén",    10, 20, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer\",\"crs\":\"EPSG:4326\",\"layers\":\"dmr5g:GrayscaleHillshade")),
                 KaType.simpleKaType("cuzklidar",    "ČUZK - LIDAR",        10, 20, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer")),
-                KaType.simpleKaType("googlelabels", "Google labels",        0, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt1.google.com/vt/lyrs=h@218000000&hl=en&src=app&x={x}&y={y}&z={z}&s="))
+                KaType.simpleKaType("googlelabels", "Google labels",        5, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt1.google.com/vt/lyrs=h@218000000&hl=en&src=app&x={x}&y={y}&z={z}&s="))
         );
     }
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
@@ -3,6 +3,7 @@ package cz.geokuk.plugins.mapy;
 import cz.geokuk.core.program.FPref;
 import cz.geokuk.framework.Model0;
 import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 
 public class MapyModel extends Model0 {
 
@@ -12,7 +13,7 @@ public class MapyModel extends Model0 {
 		return podklad;
 	}
 
-	public EKaType getPodklad() {
+	public KaType getPodklad() {
 		return podklad;
 	}
 

--- a/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
@@ -2,38 +2,96 @@ package cz.geokuk.plugins.mapy;
 
 import cz.geokuk.core.program.FPref;
 import cz.geokuk.framework.Model0;
+import cz.geokuk.plugins.mapy.kachle.data.ConfigurableMapUrlBuilder;
 import cz.geokuk.plugins.mapy.kachle.data.EKaType;
 import cz.geokuk.plugins.mapy.kachle.data.KaType;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
 public class MapyModel extends Model0 {
 
-	private KaType podklad;
+    private Collection<KaType> mapy;
+    private KaType podklad;
 
-	public KaType getKaSet() {
-		return podklad;
-	}
+    public Collection<KaType> getMapy() {
+        return mapy;
+    }
+    public void setMapy(Collection<KaType> mapy) {
+        this.mapy = mapy;
+    }
 
-	public KaType getPodklad() {
-		return podklad;
-	}
+    public KaType getKaSet() {
+        return podklad;
+    }
+    public KaType getPodklad() {
+        return podklad;
+    }
+    public void setPodklad(final KaType podklad) {
+        if (podklad == this.podklad) {
+            return;
+        }
+        this.podklad = podklad;
+        currPrefe().node(FPref.NODE_KTERE_MAPY_node).put(FPref.VALUE_MAPOVE_PODKLADY_value, podklad.getId());
+        fajruj();
+    }
 
-	public void setPodklad(final KaType podklad) {
-		if (podklad == this.podklad) {
-			return;
-		}
-		fajruj();
-	}
+    public void init() {
+        _init();
+    }
 
-	@Override
-	protected void initAndFire() {
-		final EKaType podklad = currPrefe().node(FPref.NODE_KTERE_MAPY_node).getEnum(FPref.VALUE_MAPOVE_PODKLADY_value, EKaType.TURIST_M, EKaType.class);
-		setPodklad(podklad);
-	}
+    @Override
+    protected void initAndFire() {
+        _init();
+        // Nemělo by se tu volat fajruj()?
+    }
 
-	private void fajruj() {
-		if (podklad != null) {
-			fire(new ZmenaMapNastalaEvent(getKaSet()));
-		}
-	}
+    private void fajruj() {
+        if (podklad != null) {
+            fire(new ZmenaMapNastalaEvent(getKaSet()));
+        }
+    }
 
+    private void _init() {
+        setMapy(prepareAvailableMapsCollection());
+        String podkladId = currPrefe().node(FPref.NODE_KTERE_MAPY_node).get(FPref.VALUE_MAPOVE_PODKLADY_value, EKaType.TURIST_M.name());
+        getMapy().stream().filter(m -> Objects.equals(podkladId, m.getId())).findFirst().ifPresent(
+                this::setPodklad
+        );
+    }
+
+    private Collection<KaType> prepareAvailableMapsCollection() {
+        return Stream.concat(
+                _builtinMapSources(),
+                _configurableMapSources()
+        ).collect(toList());
+    }
+
+    private Stream<KaType> _builtinMapSources() {
+        return Stream.of(EKaType.values());
+    }
+    private Stream<KaType> _configurableMapSources() {
+        return Stream.of(
+                KaType.simpleKaType("osm", 			"OSM",                  0, 18, 0, null, new ConfigurableMapUrlBuilder("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", "abc")),
+                KaType.simpleKaType("ocmde", 		"OSM German Style",     0, 18, 0, null, new ConfigurableMapUrlBuilder("https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png")),
+                KaType.simpleKaType("ocm", 			"OpenCycleMap",         0, 18, 0, null, new ConfigurableMapUrlBuilder("https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")),
+                KaType.simpleKaType("googlemaps", 	"Google Maps",          0, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?&x={x}&y={y}&z={z}", "1234", 256)),
+                KaType.simpleKaType("googlemapssat", "Google Satellite",    0, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt.google.com/vt?lyrs=s&x={x}&y={y}&z={z}", "1234", 256)),
+                KaType.simpleKaType("googlehybr", 	"Google Maps Hybrid",   0, 20, 0, null, new ConfigurableMapUrlBuilder("https://mt0.google.com/vt/lyrs=s,m@110&hl=en&x={x}&y={y}&z={z}", 256)),
+                KaType.simpleKaType("bingmap", 		"Bing Maps", 			1, 20, 0, null, new ConfigurableMapUrlBuilder("https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&mkt=en-gb&lbl=l1&stl=h&shading=hill&n=z", "0123")),
+                KaType.simpleKaType("esriimagy", 	"Esri WorldImagery", 	0, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}")),
+                KaType.simpleKaType("esriworld", 	"Esri WorldStreetMap", 	0, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}")),
+                KaType.simpleKaType("esritopo",     "Esri WorldTopoMap", 	0, 18, 0, null, new ConfigurableMapUrlBuilder("https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}")),
+                KaType.simpleKaType("binglondon",   "London Street Maps",  14, 17, 0, null, new ConfigurableMapUrlBuilder("https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&productSet=mmCB", "0123")),
+                KaType.simpleKaType("nazev",        "MTBmap.cz", 			1, 18, 0, null, new ConfigurableMapUrlBuilder("https://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png")),
+                KaType.simpleKaType("cuzktop",      "ČUZK - Topografická", 10, 19, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis/services/zmwm/MapServer/WMSServer")),
+                KaType.simpleKaType("cuzksat",      "ČUZK - Satelitní",    10, 20, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis/services/ortofoto_wm/MapServer/WMSServer")),
+                KaType.simpleKaType("cuzkater",     "ČUZK - Jen terén",    10, 20, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer\",\"crs\":\"EPSG:4326\",\"layers\":\"dmr5g:GrayscaleHillshade")),
+                KaType.simpleKaType("cuzklidar",    "ČUZK - LIDAR",        10, 20, 0, null, new ConfigurableMapUrlBuilder("https://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer")),
+                KaType.simpleKaType("googlelabels", "Google labels",        0, 22, 0, null, new ConfigurableMapUrlBuilder("https://mt1.google.com/vt/lyrs=h@218000000&hl=en&src=app&x={x}&y={y}&z={z}&s="))
+        );
+    }
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/MapyModel.java
@@ -7,9 +7,9 @@ import cz.geokuk.plugins.mapy.kachle.data.KaType;
 
 public class MapyModel extends Model0 {
 
-	private EKaType podklad;
+	private KaType podklad;
 
-	public EKaType getKaSet() {
+	public KaType getKaSet() {
 		return podklad;
 	}
 
@@ -17,12 +17,10 @@ public class MapyModel extends Model0 {
 		return podklad;
 	}
 
-	public void setPodklad(final EKaType podklad) {
+	public void setPodklad(final KaType podklad) {
 		if (podklad == this.podklad) {
 			return;
 		}
-		this.podklad = podklad;
-		currPrefe().node(FPref.NODE_KTERE_MAPY_node).putEnum(FPref.VALUE_MAPOVE_PODKLADY_value, podklad);
 		fajruj();
 	}
 

--- a/src/main/java/cz/geokuk/plugins/mapy/PodkladAction.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/PodkladAction.java
@@ -1,16 +1,16 @@
 package cz.geokuk.plugins.mapy;
 
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 
 public class PodkladAction extends MapyAction0 {
 
 	private static final long serialVersionUID = 8106696486908484270L;
 
-	public PodkladAction(final EKaType katype) {
+	public PodkladAction(final KaType katype) {
 		super(katype);
 	}
 
-	public EKaType getPodklad() {
+	public KaType getPodklad() {
 		return super.getKaType();
 	}
 

--- a/src/main/java/cz/geokuk/plugins/mapy/ZmenaMapNastalaEvent.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/ZmenaMapNastalaEvent.java
@@ -4,7 +4,7 @@
 package cz.geokuk.plugins.mapy;
 
 import cz.geokuk.framework.Event0;
-import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -16,5 +16,5 @@ import lombok.Getter;
 @Getter
 public class ZmenaMapNastalaEvent extends Event0<MapyModel> {
 
-	private final EKaType katype;
+	private final KaType katype;
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/ConfigurableMapUrlBuilder.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/ConfigurableMapUrlBuilder.java
@@ -3,13 +3,18 @@ package cz.geokuk.plugins.mapy.kachle.data;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 public class ConfigurableMapUrlBuilder implements KachleUrlBuilder {
 
 	private final String urlBase;
+	private final String subdomains;
 
 	public ConfigurableMapUrlBuilder(final String urlBase, final String subdomains, int tileSize) {
 		this.urlBase = urlBase;
+		this.subdomains = Optional.ofNullable(subdomains).map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
+
 	}
 	public ConfigurableMapUrlBuilder(final String urlBase, int tileSize) {
 		this(urlBase, null, -1);
@@ -25,12 +30,16 @@ public class ConfigurableMapUrlBuilder implements KachleUrlBuilder {
 	public URL buildUrl(final Ka kaOne) throws MalformedURLException {
 		final KaLoc kaloc = kaOne.getLoc();
 		String urlString = urlBase
-				.replace("{s}", Objects.toString("a"))
+				.replace("{s}", _subDomain())
 				.replace("{x}", Objects.toString(kaloc.getFromSzUnsignedX()))
 				.replace("{y}", Objects.toString(kaloc.getFromSzUnsignedY()))
 				.replace("{z}", Objects.toString(kaloc.getMoumer()))
 		;
 		return new URL(urlString);
+	}
+
+	private String _subDomain() {
+		return Optional.ofNullable(subdomains).map(s->s.substring(0,1)).orElse("");
 	}
 
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/ConfigurableMapUrlBuilder.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/ConfigurableMapUrlBuilder.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static cz.geokuk.util.lang.StringUtils.isBlank;
+
 public class ConfigurableMapUrlBuilder implements KachleUrlBuilder {
 
 	private final String urlBase;
@@ -13,9 +15,19 @@ public class ConfigurableMapUrlBuilder implements KachleUrlBuilder {
 
 	public ConfigurableMapUrlBuilder(final String urlBase, final String subdomains, int tileSize) {
 		this.urlBase = urlBase;
-		this.subdomains = Optional.ofNullable(subdomains).map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
-
+		this.subdomains = subdomains;
+		_validate();
 	}
+
+	private void _validate() {
+		if (isBlank(urlBase)) {
+			throw new IllegalArgumentException("urlBase cannot be blank.");
+		}
+		if (urlBase.contains("{s}") && isBlank(subdomains)) {
+			throw new IllegalArgumentException("If urlBase contains \"{s}\" placeholder, at least one subdomain character must be specfied: urlBase="+urlBase);
+		}
+	}
+
 	public ConfigurableMapUrlBuilder(final String urlBase, int tileSize) {
 		this(urlBase, null, -1);
 	}

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/ConfigurableMapUrlBuilder.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/ConfigurableMapUrlBuilder.java
@@ -1,0 +1,35 @@
+package cz.geokuk.plugins.mapy.kachle.data;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
+
+public class ConfigurableMapUrlBuilder implements KachleUrlBuilder {
+
+	private final String urlBase;
+
+	public ConfigurableMapUrlBuilder(final String urlBase, final String subdomains, int tileSize) {
+		this.urlBase = urlBase;
+	}
+	public ConfigurableMapUrlBuilder(final String urlBase, int tileSize) {
+		this(urlBase, null, -1);
+	}
+	public ConfigurableMapUrlBuilder(final String urlBase, final String subdomains) {
+		this(urlBase, subdomains, -1);
+	}
+	public ConfigurableMapUrlBuilder(final String urlBase) {
+		this(urlBase, null);
+	}
+
+	@Override
+	public URL buildUrl(final Ka kaOne) throws MalformedURLException {
+		final KaLoc kaloc = kaOne.getLoc();
+		String urlString = urlBase
+				.replace("{x}", Objects.toString(kaloc.getFromSzUnsignedX()))
+				.replace("{y}", Objects.toString(kaloc.getFromSzUnsignedY()))
+				.replace("{z}", Objects.toString(kaloc.getMoumer()))
+		;
+		return new URL(urlString);
+	}
+
+}

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/ConfigurableMapUrlBuilder.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/ConfigurableMapUrlBuilder.java
@@ -25,6 +25,7 @@ public class ConfigurableMapUrlBuilder implements KachleUrlBuilder {
 	public URL buildUrl(final Ka kaOne) throws MalformedURLException {
 		final KaLoc kaloc = kaOne.getLoc();
 		String urlString = urlBase
+				.replace("{s}", Objects.toString("a"))
 				.replace("{x}", Objects.toString(kaloc.getFromSzUnsignedX()))
 				.replace("{y}", Objects.toString(kaloc.getFromSzUnsignedY()))
 				.replace("{z}", Objects.toString(kaloc.getMoumer()))

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
@@ -4,7 +4,7 @@ import java.awt.event.KeyEvent;
 
 import javax.swing.KeyStroke;
 
-public enum EKaType {
+public enum EKaType implements KaType {
 
     // Mapové podklady, dále neprůhledné
 	BASE_M(false, 0, 19, 19, "Základní", "Základní mapa se silnicemi.", KeyEvent.VK_Z, KeyStroke.getKeyStroke('z'), new MapyCzUrlBuilder("base-m")),
@@ -86,45 +86,43 @@ public enum EKaType {
 
 	}
 
-	public int fitMoumer(int moumer) {
-		if (moumer < minMoumer) {
-			moumer = minMoumer;
-		}
-		if (moumer > maxMoumer) {
-			moumer = maxMoumer;
-		}
-		return moumer;
-	}
-
-	public KeyStroke getKeyStroke() {
+	@Override
+    public KeyStroke getKeyStroke() {
 		return keyStroke;
 	}
 
-	public int getKlavesa() {
+	@Override
+    public int getKlavesa() {
 		return klavesa;
 	}
 
-	public int getMaxAutoMoumer() {
+	@Override
+    public int getMaxAutoMoumer() {
 		return maxAutoMoumer;
 	}
 
-	public int getMaxMoumer() {
+	@Override
+    public int getMaxMoumer() {
 		return maxMoumer;
 	}
 
-	public int getMinMoumer() {
+	@Override
+    public int getMinMoumer() {
 		return minMoumer;
 	}
 
-	public String getNazev() {
+	@Override
+    public String getNazev() {
 		return nazev;
 	}
 
-	public String getPopis() {
+	@Override
+    public String getPopis() {
 		return popis;
 	}
 
-	public KachleUrlBuilder getUrlBuilder() {
+	@Override
+    public KachleUrlBuilder getUrlBuilder() {
 		return urlBuilder;
 	}
 

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
@@ -111,6 +111,10 @@ public enum EKaType implements KaType {
     }
 
     @Override
+    public String getId() {
+        return name();
+    }
+    @Override
     public String getNazev() {
         return nazev;
     }

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
@@ -1,23 +1,22 @@
 package cz.geokuk.plugins.mapy.kachle.data;
 
+import javax.swing.*;
 import java.awt.event.KeyEvent;
-
-import javax.swing.KeyStroke;
 
 public enum EKaType implements KaType {
 
     // Mapové podklady, dále neprůhledné
-	BASE_M(false, 0, 19, 19, "Základní", "Základní mapa se silnicemi.", KeyEvent.VK_Z, KeyStroke.getKeyStroke('z'), new MapyCzUrlBuilder("base-m")),
-	TURIST_M(false, 0, 19, 19, "Turistická", "Turistická mapa.", KeyEvent.VK_T, KeyStroke.getKeyStroke('t'), new MapyCzUrlBuilder("turist-m")),
-	OPHOTO_M(true, 0, 20, 20, "Letecká", "Letecká ortho foto mapa", KeyEvent.VK_L, KeyStroke.getKeyStroke('f'), new MapyCzUrlBuilder("ophoto-m")),
-	WTURIST_WINTER_M(false, 0, 19, 19, "Turistická zimní", "Zimní turistická mapa.", KeyEvent.VK_M, KeyStroke.getKeyStroke('w'), new MapyCzUrlBuilder("wturist_winter-m")),
-	OPHOTO1415_M(true, 0, 20, 20, "Letecká 2015", "Starší fotomapa", 0, null, new MapyCzUrlBuilder("ophoto1415-m")),
-	OPHOTO1012_M(true, 0, 19, 19, "Letecká 2012", "Starší fotomapa", 0, null, new MapyCzUrlBuilder("ophoto1012-m")),
-	OPHOTO0406_M(true, 0, 19, 19, "Letecká 2006", "Starší fotomapa", KeyEvent.VK_6, null, new MapyCzUrlBuilder("ophoto0406-m")),
-	OPHOTO0203_M(true, 0, 18, 18, "Letecká 2003", "Starší fotomapa", KeyEvent.VK_3, null, new MapyCzUrlBuilder("ophoto0203-m")),
-	ZEMEPIS_M(false, 0, 18, 18, "Zeměpisná", "Zeměpisná mapa", KeyEvent.VK_G, KeyStroke.getKeyStroke('g'), new MapyCzUrlBuilder("zemepis-m")),
-	BASE_M_TRAF_DOWN(false, 0, 19, 19, "Dopravní", "Dopravní mapa taková vyšedlá.", 0, null, new MapyCzUrlBuilder("base-m-traf-down")),
-	ARMY2_M(true, 0, 15, 15, "Historická", "Historická mapa z let 1836-52", KeyEvent.VK_H, KeyStroke.getKeyStroke('h'), new MapyCzUrlBuilder("army2-m")),
+    BASE_M(false, 0, 19, 19, "Základní", "Základní mapa se silnicemi.", KeyEvent.VK_Z, KeyStroke.getKeyStroke('z'), new MapyCzUrlBuilder("base-m")),
+    TURIST_M(false, 0, 19, 19, "Turistická", "Turistická mapa.", KeyEvent.VK_T, KeyStroke.getKeyStroke('t'), new MapyCzUrlBuilder("turist-m")),
+    OPHOTO_M(true, 0, 20, 20, "Letecká", "Letecká ortho foto mapa", KeyEvent.VK_L, KeyStroke.getKeyStroke('f'), new MapyCzUrlBuilder("ophoto-m")),
+    WTURIST_WINTER_M(false, 0, 19, 19, "Turistická zimní", "Zimní turistická mapa.", KeyEvent.VK_M, KeyStroke.getKeyStroke('w'), new MapyCzUrlBuilder("wturist_winter-m")),
+    OPHOTO1415_M(true, 0, 20, 20, "Letecká 2015", "Starší fotomapa", 0, null, new MapyCzUrlBuilder("ophoto1415-m")),
+    OPHOTO1012_M(true, 0, 19, 19, "Letecká 2012", "Starší fotomapa", 0, null, new MapyCzUrlBuilder("ophoto1012-m")),
+    OPHOTO0406_M(true, 0, 19, 19, "Letecká 2006", "Starší fotomapa", KeyEvent.VK_6, null, new MapyCzUrlBuilder("ophoto0406-m")),
+    OPHOTO0203_M(true, 0, 18, 18, "Letecká 2003", "Starší fotomapa", KeyEvent.VK_3, null, new MapyCzUrlBuilder("ophoto0203-m")),
+    ZEMEPIS_M(false, 0, 18, 18, "Zeměpisná", "Zeměpisná mapa", KeyEvent.VK_G, KeyStroke.getKeyStroke('g'), new MapyCzUrlBuilder("zemepis-m")),
+    BASE_M_TRAF_DOWN(false, 0, 19, 19, "Dopravní", "Dopravní mapa taková vyšedlá.", 0, null, new MapyCzUrlBuilder("base-m-traf-down")),
+    ARMY2_M(true, 0, 15, 15, "Historická", "Historická mapa z let 1836-52", KeyEvent.VK_H, KeyStroke.getKeyStroke('h'), new MapyCzUrlBuilder("army2-m")),
 
 // Nefunkční mapy k 16.11.2019
 //	OPEN_STREAT(false, 0, 18, 18, "Openstreetmap", "Openstreetmap.", KeyEvent.VK_O, KeyStroke.getKeyStroke('o'), new OpenStreatMapUrlBuilder("https://b.tile.openstreetmap.org/")),
@@ -29,101 +28,101 @@ public enum EKaType implements KaType {
 //	TUR_FREEMAP_SK_K(false, 0, 18, 18, "Slovensko lyžařská  ", "turistika.freemap.sk - lyžařská mapa", 0, null, new OpenStreatMapUrlBuilder("http://c.freemap.sk/K/")),
 //
 
-	// Nefunguje, jakási ochrana přes kukačku
-	// HIKING_SK_TOPO (true, false, 0, 18, 18, "Slovensko turistická ", "mapy.hiking.sk - topo", 0, null, new OpenStreatMapUrlBuilder("http://mapy.hiking.sk/layers/topo/")),
+    // Nefunguje, jakási ochrana přes kukačku
+    // HIKING_SK_TOPO (true, false, 0, 18, 18, "Slovensko turistická ", "mapy.hiking.sk - topo", 0, null, new OpenStreatMapUrlBuilder("http://mapy.hiking.sk/layers/topo/")),
 
-	// Todo vyřešit problémy s certifikátem
-	// OPEN_CYKLO(true, false, 0, 18, 18, "Open cyclo", "Open streat map.", KeyEvent.VK_Y, KeyStroke.getKeyStroke('c') , new OpenStreatMapUrlBuilder("https://b.tile.thunderforest.com/cycle/")),
+    // Todo vyřešit problémy s certifikátem
+    // OPEN_CYKLO(true, false, 0, 18, 18, "Open cyclo", "Open streat map.", KeyEvent.VK_Y, KeyStroke.getKeyStroke('c') , new OpenStreatMapUrlBuilder("https://b.tile.thunderforest.com/cycle/")),
 
-	;
+    ;
 
-	// super("Turistické trasy");
-	// putValue(SHORT_DESCRIPTION, "Turistické trasy, červená, modrá, zelená, žlutá.");
-	// putValue(MNEMONIC_KEY, KeyEvent.VK_U);
-	// putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke('u'));
+    // super("Turistické trasy");
+    // putValue(SHORT_DESCRIPTION, "Turistické trasy, červená, modrá, zelená, žlutá.");
+    // putValue(MNEMONIC_KEY, KeyEvent.VK_U);
+    // putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke('u'));
 
-	private final int minMoumer;
-	private final int maxMoumer;
-	private final int maxAutoMoumer;
-	private final String nazev;
-	private final String popis;
-	private final int klavesa;
-	private final KeyStroke keyStroke;
-	private KachleUrlBuilder urlBuilder;
+    private final int minMoumer;
+    private final int maxMoumer;
+    private final int maxAutoMoumer;
+    private final String nazev;
+    private final String popis;
+    private final int klavesa;
+    private final KeyStroke keyStroke;
+    private final KachleUrlBuilder urlBuilder;
 
-	/**
-	 * @param podklad
-	 *            true, pokud se jedná o neprůhledný podlad, false jinak.
-	 * @param jeMozneNavrsitTexty
-	 *            zde je možné ještě aplikovat samostatnou vrstvu s texty. Zadejte true, pokud mapa texty neobsahuje (napříkald fotomapy).
-	 * @param minMoumer
-	 *            Minimáklní měřítko, ke kterému jsou podklady. Věřme, že to bude dne světšinou 0. (U starých seznamových map to bylo 3 nebo 4).
-	 * @param maxMoumer
-	 *            Maximální měřítko, pro který jsou kachle.
-	 * @param maxAutoMoumer
-	 *            už přesně nevím, nutno analyzovat, nastavujem to stejnějako maxMoumer
-	 * @param nazev
-	 *            Název mapy, tak se objeví v menu.
-	 * @param popis
-	 *            Bližší popis mapy, objeví se jako tooltip v menu.
-	 * @param klavesa
-	 *            Hot-key, která mapu vyvolá.
-	 * @param keyStroke
-	 *            Písmeno z nazev, které lze použít pro výběr při rozbaleném menu.
-	 * @param urlBuilder
-	 *            Implementace třídy, která sestaví URL pro zobrazení mapy.
-	 */
-	private EKaType(final boolean jeMozneNavrsitTexty, final int minMoumer, final int maxMoumer, final int maxAutoMoumer, final String nazev, final String popis, final int klavesa,
-	        final KeyStroke keyStroke, final KachleUrlBuilder urlBuilder) {
-		this.minMoumer = minMoumer;
-		this.maxMoumer = maxMoumer;
-		this.maxAutoMoumer = maxAutoMoumer;
-		this.nazev = nazev;
-		this.popis = popis;
-		this.klavesa = klavesa;
-		this.keyStroke = keyStroke;
-		this.urlBuilder = urlBuilder;
+    /**
+     * \@param podklad                   true, pokud se jedná o neprůhledný podlad, false jinak.
+     *
+     * @param ignoredJeMozneNavrsitTexty zde je možné ještě aplikovat samostatnou vrstvu s texty. Zadejte true, pokud mapa texty neobsahuje (napříkald fotomapy).
+     * @param minMoumer                  Minimáklní měřítko, ke kterému jsou podklady. Věřme, že to bude dne světšinou 0. (U starých seznamových map to bylo 3 nebo 4).
+     * @param maxMoumer                  Maximální měřítko, pro který jsou kachle.
+     * @param maxAutoMoumer              už přesně nevím, nutno analyzovat, nastavujem to stejnějako maxMoumer
+     * @param nazev                      Název mapy, tak se objeví v menu.
+     * @param popis                      Bližší popis mapy, objeví se jako tooltip v menu.
+     * @param klavesa                    Hot-key, která mapu vyvolá.
+     * @param keyStroke                  Písmeno z nazev, které lze použít pro výběr při rozbaleném menu.
+     * @param urlBuilder                 Implementace třídy, která sestaví URL pro zobrazení mapy.
+     */
+    EKaType(
+            final boolean ignoredJeMozneNavrsitTexty,
+            final int minMoumer,
+            final int maxMoumer,
+            final int maxAutoMoumer,
+            final String nazev,
+            final String popis,
+            final int klavesa,
+            final KeyStroke keyStroke,
+            final KachleUrlBuilder urlBuilder
+    ) {
+        this.minMoumer = minMoumer;
+        this.maxMoumer = maxMoumer;
+        this.maxAutoMoumer = maxAutoMoumer;
+        this.nazev = nazev;
+        this.popis = popis;
+        this.klavesa = klavesa;
+        this.keyStroke = keyStroke;
+        this.urlBuilder = urlBuilder;
 
-	}
+    }
 
-	@Override
+    @Override
     public KeyStroke getKeyStroke() {
-		return keyStroke;
-	}
+        return keyStroke;
+    }
 
-	@Override
+    @Override
     public int getKlavesa() {
-		return klavesa;
-	}
+        return klavesa;
+    }
 
-	@Override
+    @Override
     public int getMaxAutoMoumer() {
-		return maxAutoMoumer;
-	}
+        return maxAutoMoumer;
+    }
 
-	@Override
+    @Override
     public int getMaxMoumer() {
-		return maxMoumer;
-	}
+        return maxMoumer;
+    }
 
-	@Override
+    @Override
     public int getMinMoumer() {
-		return minMoumer;
-	}
+        return minMoumer;
+    }
 
-	@Override
+    @Override
     public String getNazev() {
-		return nazev;
-	}
+        return nazev;
+    }
 
-	@Override
+    @Override
     public String getPopis() {
-		return popis;
-	}
+        return popis;
+    }
 
-	@Override
+    @Override
     public KachleUrlBuilder getUrlBuilder() {
-		return urlBuilder;
-	}
+        return urlBuilder;
+    }
 
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
@@ -121,7 +121,7 @@ public enum EKaType implements KaType {
 
     @Override
     public String getPopis() {
-        return popis;
+        return popis == null ? nazev : popis;
     }
 
     @Override

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/EKaType.java
@@ -129,4 +129,13 @@ public enum EKaType implements KaType {
         return urlBuilder;
     }
 
+    @Override public boolean isIgnored() {
+        return false;
+    }
+    @Override public boolean isTransparent() {
+        return false;
+    }
+    @Override public boolean isOverleay() {
+        return false;
+    }
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/Ka.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/Ka.java
@@ -17,7 +17,7 @@ public class Ka {
 	// private int DOPLNKOVAC = 1<<28;
 
 	private final KaLoc loc;
-	private final EKaType type;
+	private final KaType type;
 
 	@Override
 	public String toString() {
@@ -25,7 +25,7 @@ public class Ka {
 	}
 
 	public String typToString() {
-		return type.name();
+		return type.toString();
 	}
 
 	/** Zbuilduje URL ke kachli 256*256 mapy */

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/Ka.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/Ka.java
@@ -21,11 +21,11 @@ public class Ka {
 
 	@Override
 	public String toString() {
-		return getLoc().toString() + "*" + type;
+		return getLoc().toString() + "*" + type.getId();
 	}
 
-	public String typToString() {
-		return type.toString();
+	public String typToId() {
+		return type.getId();
 	}
 
 	/** Zbuilduje URL ke kachli 256*256 mapy */

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
@@ -1,0 +1,32 @@
+package cz.geokuk.plugins.mapy.kachle.data;
+
+import javax.swing.*;
+
+public interface KaType {
+    /** Minimální měřítko, ke kterému jsou podklady. Věřme, že to bude dnes většinou 0. (U starých seznamových map to bylo 3 nebo 4). */
+    int getMinMoumer();
+    /** Maximální měřítko, pro který jsou kachle. */
+    int getMaxMoumer();
+    /** Už přesně nevím [veverka], nutno analyzovat, nastavujem to stejnějako maxMoumer. */
+    int getMaxAutoMoumer();
+    /** Název mapy, tak se objeví v menu. */
+    String getNazev();
+    /** Bližší popis mapy, objeví se jako tooltip v menu. */
+    String getPopis();
+    /** Hot-key, která mapu vyvolá. */
+    int getKlavesa();
+    /** Písmeno z nazev, které lze použít pro výběr při rozbaleném menu. */
+    KeyStroke getKeyStroke();
+    /** Implementace třídy, která sestaví URL pro zobrazení mapy. */
+    KachleUrlBuilder getUrlBuilder();
+
+    default int fitMoumer(int moumer)  {
+		if (moumer < getMinMoumer()) {
+			moumer = getMinMoumer();
+		}
+		if (moumer > getMaxMoumer()) {
+			moumer = getMaxMoumer();
+		}
+		return moumer;
+	}
+}

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
@@ -24,6 +24,11 @@ public interface KaType {
     KeyStroke getKeyStroke();
     /** Implementace třídy, která sestaví URL pro zobrazení mapy. */
     KachleUrlBuilder getUrlBuilder();
+
+    boolean isIgnored();
+    boolean isTransparent();
+    boolean isOverleay();
+
     default int fitMoumer(int moumer)  {
 		if (moumer < getMinMoumer()) {
 			moumer = getMinMoumer();
@@ -82,6 +87,15 @@ public interface KaType {
             }
             @Override public KachleUrlBuilder getUrlBuilder() {
                 return urlBuilder;
+            }
+            @Override public boolean isIgnored() {
+                return false;
+            }
+            @Override public boolean isTransparent() {
+                return false;
+            }
+            @Override public boolean isOverleay() {
+                return false;
             }
 
             @Override public String toString() {

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
@@ -1,10 +1,13 @@
 package cz.geokuk.plugins.mapy.kachle.data;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.swing.*;
 
 public interface KaType {
     /** Minimální měřítko, ke kterému jsou podklady. Věřme, že to bude dnes většinou 0. (U starých seznamových map to bylo 3 nebo 4). */
     int getMinMoumer();
+
     /** Maximální měřítko, pro který jsou kachle. */
     int getMaxMoumer();
     /** Už přesně nevím [veverka], nutno analyzovat, nastavujem to stejnějako maxMoumer. */
@@ -19,7 +22,6 @@ public interface KaType {
     KeyStroke getKeyStroke();
     /** Implementace třídy, která sestaví URL pro zobrazení mapy. */
     KachleUrlBuilder getUrlBuilder();
-
     default int fitMoumer(int moumer)  {
 		if (moumer < getMinMoumer()) {
 			moumer = getMinMoumer();
@@ -29,4 +31,41 @@ public interface KaType {
 		}
 		return moumer;
 	}
+
+    static KaType simpleKaType(
+        int minMoumer,
+        int maxMoumer,
+        @Nonnull String nazev,
+        @Nullable String popis,
+        int klavesa,
+        @Nullable KeyStroke keyStroke,
+        @Nonnull KachleUrlBuilder urlBuilder
+    ) {
+        return new KaType() {
+            @Override public int getMinMoumer() {
+                return minMoumer;
+            }
+            @Override public int getMaxMoumer() {
+                return maxMoumer;
+            }
+            @Override public int getMaxAutoMoumer() {
+                return maxMoumer;
+            }
+            @Override public String getNazev() {
+                return nazev;
+            }
+            @Override public String getPopis() {
+                return popis == null ? nazev : popis;
+            }
+            @Override public int getKlavesa() {
+                return klavesa;
+            }
+            @Override public KeyStroke getKeyStroke() {
+                return keyStroke;
+            }
+            @Override public KachleUrlBuilder getUrlBuilder() {
+                return urlBuilder;
+            }
+        };
+    };
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
@@ -83,6 +83,24 @@ public interface KaType {
             @Override public KachleUrlBuilder getUrlBuilder() {
                 return urlBuilder;
             }
+
+            @Override public String toString() {
+                return _toString();
+            }
         };
     };
+
+    default String _toString() {
+        return getClass().getSimpleName() + "{" +
+                "id=" + getId() +
+                ", nazev=" + getNazev() +
+                ", popis=" + getPopis() +
+                ", minMoumer=" + getMinMoumer() +
+                ", maxMoumer=" + getMaxMoumer() +
+                ", maxAutoMoumer=" + getMaxAutoMoumer() +
+                ", klavesa=" + getKlavesa() +
+                ", keyStroke=" + getKeyStroke() +
+                ", urlBuilder=" + getUrlBuilder() +
+            '}';
+    }
 }

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/data/KaType.java
@@ -12,6 +12,8 @@ public interface KaType {
     int getMaxMoumer();
     /** Už přesně nevím [veverka], nutno analyzovat, nastavujem to stejnějako maxMoumer. */
     int getMaxAutoMoumer();
+    /** Id mapy, jak se zapisuje do konfigurace. */
+    String getId();
     /** Název mapy, tak se objeví v menu. */
     String getNazev();
     /** Bližší popis mapy, objeví se jako tooltip v menu. */
@@ -33,13 +35,25 @@ public interface KaType {
 	}
 
     static KaType simpleKaType(
-        int minMoumer,
-        int maxMoumer,
-        @Nonnull String nazev,
-        @Nullable String popis,
-        int klavesa,
-        @Nullable KeyStroke keyStroke,
-        @Nonnull KachleUrlBuilder urlBuilder
+            @Nonnull String id,
+            @Nonnull String nazev,
+            int minMoumer,
+            int maxMoumer,
+            int klavesa,
+            @Nullable KeyStroke keyStroke,
+            @Nonnull KachleUrlBuilder urlBuilder
+    ) {
+        return simpleKaType(id, nazev, null, minMoumer, maxMoumer, klavesa, keyStroke, urlBuilder);
+    }
+    static KaType simpleKaType(
+            @Nonnull String id,
+            @Nonnull String nazev,
+            @Nullable String popis,
+            int minMoumer,
+            int maxMoumer,
+            int klavesa,
+            @Nullable KeyStroke keyStroke,
+            @Nonnull KachleUrlBuilder urlBuilder
     ) {
         return new KaType() {
             @Override public int getMinMoumer() {
@@ -50,6 +64,9 @@ public interface KaType {
             }
             @Override public int getMaxAutoMoumer() {
                 return maxMoumer;
+            }
+            @Override public String getId() {
+                return id;
             }
             @Override public String getNazev() {
                 return nazev;

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/gui/JKachlovnik.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/gui/JKachlovnik.java
@@ -34,7 +34,7 @@ public abstract class JKachlovnik extends JSingleSlide0 implements AfterEventRec
 
 	private static final Pocitadlo pocitKachliVKachlovniku2 = new PocitadloMalo("#kachlí v kachlovníku", "");
 
-	private EKaType katype = null;
+	private KaType katype = null;
 
 	private KachleModel kachleModel;
 
@@ -86,11 +86,7 @@ public abstract class JKachlovnik extends JSingleSlide0 implements AfterEventRec
 		init(true);
 	}
 
-	/**
-	 * @param aKachloTypes
-	 *            the kachloTypes to set
-	 */
-	public void setKachloType(final EKaType katype) {
+	public void setKachloType(final KaType katype) {
 		if (this.katype == katype) {
 			return;
 		}

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/gui/JKachlovnikDoRohu.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/gui/JKachlovnikDoRohu.java
@@ -1,6 +1,7 @@
 package cz.geokuk.plugins.mapy.kachle.gui;
 
 import cz.geokuk.plugins.mapy.kachle.data.EKaType;
+import cz.geokuk.plugins.mapy.kachle.data.KaType;
 import cz.geokuk.plugins.mapy.kachle.podklady.Priority;
 
 public class JKachlovnikDoRohu extends JKachlovnik {
@@ -12,7 +13,7 @@ public class JKachlovnikDoRohu extends JKachlovnik {
 	}
 
 	@Override
-	public void setKachloType(final EKaType aKachloSet) {
+	public void setKachloType(final KaType aKachloSet) {
 		// nehezké takto přepsat metodu
 		super.setKachloType(EKaType.OPHOTO_M);
 	}

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/podklady/KachleDBManager.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/podklady/KachleDBManager.java
@@ -82,7 +82,7 @@ class KachleDBManager implements KachleManager {
 		try {
 			final ISqlJetTable table = database.getTable(TABLE_NAME);
 			database.beginTransaction(SqlJetTransactionMode.READ_ONLY);
-			cursor = table.lookup(table.getPrimaryKeyIndexName(), ki.getLoc().getFromSzUnsignedX(), ki.getLoc().getFromSzUnsignedY(), ki.getLoc().getMoumer(), ki.typToString());
+			cursor = table.lookup(table.getPrimaryKeyIndexName(), ki.getLoc().getFromSzUnsignedX(), ki.getLoc().getFromSzUnsignedY(), ki.getLoc().getMoumer(), ki.typToId());
 			if (cursor.eof()) {
 				return null;
 			}
@@ -133,8 +133,8 @@ class KachleDBManager implements KachleManager {
 				final KaLoc kaloc = ki.getLoc();
 				final int kx = kaloc.getFromSzUnsignedX();
 				final int ky = kaloc.getFromSzUnsignedY();
-				log.debug("Adding {} {} {} {}", kx, ky, kaloc.getMoumer(), ki.typToString());
-				database.getTable(TABLE_NAME).insertOr(SqlJetConflictAction.REPLACE, kx, ky, kaloc.getMoumer(), ki.typToString(), dataToSave);
+				log.debug("Adding {} {} {} {}", kx, ky, kaloc.getMoumer(), ki.typToId());
+				database.getTable(TABLE_NAME).insertOr(SqlJetConflictAction.REPLACE, kx, ky, kaloc.getMoumer(), ki.typToId(), dataToSave);
 			}
 		} catch (final SqlJetException e) {
 			log.error("A database error has occurred!", e);

--- a/src/main/java/cz/geokuk/plugins/mapy/kachle/podklady/KachloDownloader.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/kachle/podklady/KachloDownloader.java
@@ -43,7 +43,9 @@ public class KachloDownloader {
 		// if (Math.random() > 0.5 && url.toString().contains("hybrid")) {
 		// throw new IOException("Nasimulovaná chyba hybrid");
 		// }
-
+		// FIXME: Tady by to chtělo vyřešit přesměrování (kódy 3xx).
+		//        Většinou sice stačí jen změnit protokol z http: na https:, ale co s tím prostý uživatel udělá, že.
+		//
 		final DataHoldingInputStream dhis = new DataHoldingInputStream(url.openStream());
 		final Image img;
 		try (InputStream stm = new BufferedInputStream(dhis)) {

--- a/src/main/java/cz/geokuk/plugins/mapy/stahovac/JKachleOflinerDialog.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/stahovac/JKachleOflinerDialog.java
@@ -107,7 +107,7 @@ public class JKachleOflinerDialog extends JMyDialog0 implements AfterEventReceiv
 	private class TotoSeTaha {
 		private int minmoumer;
 		private int maxmoumer;
-		private EKaType katype;
+		private KaType katype;
 	}
 
 	private static final long serialVersionUID = 7180968190465321695L;
@@ -126,7 +126,7 @@ public class JKachleOflinerDialog extends JMyDialog0 implements AfterEventReceiv
 
 	private KachleModel kachleModel;
 
-	private EKaType katype;
+	private KaType katype;
 
 	private int xminmoumer;
 

--- a/src/main/java/cz/geokuk/plugins/mapy/stahovac/JKachleOflinerDialog.java
+++ b/src/main/java/cz/geokuk/plugins/mapy/stahovac/JKachleOflinerDialog.java
@@ -223,7 +223,7 @@ public class JKachleOflinerDialog extends JMyDialog0 implements AfterEventReceiv
 		return String.format("<html>Budou stahovány dlaždice mapových pokladů <b>%s</b> v rozmění měřítek " + " <b>&lt;%d,%d&gt;</b>"
 				+ " nyní natavte v hlavním okně výřez mapy který chcete stáhnout. Výřez můžete" + " nastavit v libovolném měřítku a v na libovolném mapovém podkladu. "
 				+ " Pak spusťte stahování tlačítkem. Stahování poběží na pozadí. V servisním okně lze sledovat," + " jak se zkracují frony. Stahování nelze zastavit jinak než ukončením programu.",
-				totoSeTaha.katype, totoSeTaha.minmoumer, totoSeTaha.maxmoumer);
+				totoSeTaha.katype.getId(), totoSeTaha.minmoumer, totoSeTaha.maxmoumer);
 	}
 
 	private void prepocetKachli() {

--- a/src/main/java/cz/geokuk/util/gui/MenuStrujce.java
+++ b/src/main/java/cz/geokuk/util/gui/MenuStrujce.java
@@ -41,11 +41,15 @@ public abstract class MenuStrujce {
 		}
 	}
 
-	protected void item(final ToggleAction0 action, final ButtonGroup bg) {
+	protected void item(final ToggleAction0 action, final ButtonGroup bg, boolean selected) {
 		item = new JRadioButtonMenuItem(action);
 		action.join(item);
+
 		menu.add(item);
 		bg.add(item);
+
+		item.setSelected(selected);
+		bg.setSelected(item.getModel(), selected);
 	}
 
 	protected abstract void makeMenu();

--- a/src/main/java/cz/geokuk/util/index2d/BoundingRect.java
+++ b/src/main/java/cz/geokuk/util/index2d/BoundingRect.java
@@ -3,6 +3,12 @@
  */
 package cz.geokuk.util.index2d;
 
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+
 /**
  * @author Martin Veverka
  *
@@ -28,8 +34,11 @@ public class BoundingRect {
 		xx2 = aXx2;
 		yy2 = aYy2;
 
-		if (xx2 < xx1 || yy2 < yy1) {
-			throw new RuntimeException("Spatne presahy " + this);
+        boolean xx2_lt_xx1 = xx2 < xx1;
+        boolean yy2_lt_yy1 = yy2 < yy1;
+        if (xx2_lt_xx1 || yy2_lt_yy1) {
+            String msg = Stream.of(xx2_lt_xx1 ? "xx2 < xx1" : null, yy2_lt_yy1 ? "yy2 < yy1" : null).filter(Objects::nonNull).collect(joining(" && ", "Spatne presahy ", " "));
+            throw new RuntimeException(msg + this);
 		}
 	}
 

--- a/src/main/resources/cz/geokuk/plugins/mapy/defaultMapDefinitions.utf-8.json
+++ b/src/main/resources/cz/geokuk/plugins/mapy/defaultMapDefinitions.utf-8.json
@@ -1,0 +1,155 @@
+[
+  {
+    "name": "osm", "ignore": true, "alt": "OSM", "tileUrl": "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    "subdomains": "abc",
+    "attribution": "&copy; <a href='http://openstreetmap.org'>OpenStreetMap</a> contributors, <a href='http://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a>"
+  },
+  {
+    "name": "ocmde", "ignore": false, "alt": "OSM German Style", "tileUrl": "https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png",
+    "subdomains": "abc",
+    "attribution": "&copy; <a href='http://openstreetmap.org'>OpenStreetMap</a> contributors, <a href='http://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a>"
+  },
+  {
+    "name": "ocm", "ignore": false, "alt": "OpenCycleMap", "tileUrl": "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png"
+  },
+  {
+    "name": "googlemaps", "ignore": false, "alt": "Google Maps", "tileUrl": "https://mt.google.com/vt?&x={x}&y={y}&z={z}",
+    "maxZoom": 22, "subdomains": "1234", "tileSize": 256,
+    "attribution": "<a href='https://maps.google.com/'>Google</a> Maps"
+  },
+  {
+    "name": "googlemapssat", "ignore": false, "alt": "Google Satellite", "tileUrl": "https://mt.google.com/vt?lyrs=s&x={x}&y={y}&z={z}",
+    "maxZoom": 22, "subdomains": "1234", "tileSize": 256,
+    "attribution": "<a href='https://maps.google.com/'>Google</a> Maps Satellite"
+  },
+  {
+    "name": "googlehybr", "ignore": false, "alt": "Google Maps Hybrid", "tileUrl": "http://mt0.google.com/vt/lyrs=s,m@110&hl=en&x={x}&y={y}&z={z}",
+    "minZoom": 0, "maxZoom": 20, "tileSize": 256, "attribution": "Google Maps"
+  },
+  {
+    "name": "TURIST_M", "ignore": true, "alt": "Mapy.cz turistická", "tileUrl": "http://mapserver.mapy.cz/wturist-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 18, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © Seznam.cz, a.si &amp; spol."
+  },
+  {
+    "name": "WTURIST_WINTER_M", "ignore": true, "alt": "Mapy.cz zimní", "tileUrl": "http://mapserver.mapy.cz/wturist_winter-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 18, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © Seznam.cz, a.si &amp; spol."
+  },
+  {
+    "name": "BASE_M", "ignore": true, "alt": "Mapy.cz základní", "tileUrl": "http://mapserver.mapy.cz/base-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 18, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © Seznam.cz,a.s, © Přispěvatelé <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a>, © NASA"
+  },
+  {
+    "name": "BASE_M_TRAF_DOWN", "ignore": true, "alt": "Mapy.cz dopravní", "tileUrl": "http://mapserver.mapy.cz/base-m/{z}-{x}-{y}?s=0.2&dm=Luminosity",
+    "minZoom": 5, "maxZoom": 18, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © Seznam.cz,a.s, © Přispěvatelé <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a>, © NASA"
+  },
+  {
+    "name": "OPHOTO_M", "ignore": true, "alt": "Mapy.cz letecká", "tileUrl": "http://mapserver.mapy.cz/ophoto-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 20, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © Seznam.cz,a.s, © GEODIS BRNO,s.r.o."
+  },
+  {
+    "name": "OPHOTO1415_M", "ignore": true, "alt": "Mapy.cz letecká 2015", "tileUrl": "//mapserver.mapy.cz/ophoto1415-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 19,
+    "attribution": "© <a href='http://www.seznam.cz' target='_blank'>Seznam.cz, a.s.</a>, © <a href='http://eox.at/' target='_blank'>EOX IT Services GmbH</a>, © <a href='http://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap</a>"
+  },
+  {
+    "name": "OPHOTO1012_M", "ignore": true, "alt": "Mapy.cz letecká 2012", "tileUrl": "//mapserver.mapy.cz/ophoto1012-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 19,
+    "attribution": "© <a href='http://www.seznam.cz' target='_blank'>Seznam.cz, a.s.</a>, © GEODIS BRNO,s.r.o."
+  },
+  {
+    "name": "OPHOTO0406_M", "ignore": true, "alt": "Mapy.cz letecká 2006", "tileUrl": "http://mapserver.mapy.cz/ophoto0406-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 19, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © Seznam.cz,a.s, © GEODIS BRNO,s.r.o."
+  },
+  {
+    "name": "OPHOTO0203_M", "ignore": true, "alt": "Mapy.cz letecká 2003", "tileUrl": "http://mapserver.mapy.cz/ophoto0203-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 19, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © Seznam.cz,a.s, © GEODIS BRNO,s.r.o."
+  },
+  {
+    "name": "text_m", "ignore": true, "alt": "Mapy.cz textová", "tileUrl": "http://mapserver.mapy.cz/april17-m/{z}-{x}-{y} ",
+    "minZoom": 5, "maxZoom": 18, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg ' /> © Seznam.cz,a.s, © Přispěvatelé <a href='http://www.openstreetmap.org/copyright '>OpenStreetMap</a>, © NASA"
+  },
+  {
+    "name": "ZEMEPIS_M", "ignore": true, "alt": "Mapy.cz zeměpisná", "tileUrl": "http://mapserver.mapy.cz/zemepis-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 18, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © Seznam.cz,a.s, © Přispěvatelé <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a>, © NASA"
+  },
+  {
+    "name": "ARMY2_M", "ignore": true, "alt": "Mapy.cz 2. vojenské mapování", "tileUrl": "http://mapserver.mapy.cz/army2-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 15, "subdomains": "1234",
+    "attribution": "<img src='http://mapy.cz/img/logo-small.svg' /> © 2nd Military Survey, © Datový podklad MŽP ČR, © Laboratoř geoinformatiky UJEP"
+  },
+  {
+    "name": "bingmap", "ignore": true, "alt": "Bing Maps", "tileUrl": "https://ecn.t{s}.tiles.virtualearth.net/tiles/r{q}?g=864&mkt=en-gb&lbl=l1&stl=h&shading=hill&n=z",
+    "minZoom": 1, "maxZoom": 20, "subdomains": "0123",
+    "attribution": "<a href='https://www.bing.com/maps/'>Bing</a> map data copyright Microsoft and its suppliers"
+  },
+  {
+    "name": "bingaerial", "ignore": true, "alt": "Bing Aerial View", "tileUrl": "https://ecn.t{s}.tiles.virtualearth.net/tiles/a{q}?g=737&n=z",
+    "minZoom": 1, "maxZoom": 20, "subdomains": "0123",
+    "attribution": "<a href='https://www.bing.com/maps/'>Bing</a> map data copyright Microsoft and its suppliers"
+  },
+  {
+    "name": "esriimagy", "ignore": false, "alt": "Esri WorldImagery", "tileUrl": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
+  },
+  {
+    "name": "esriworld", "ignore": false, "alt": "Esri WorldStreetMap", "tileUrl": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
+    "attribution": "Tiles &copy; Esri"
+  },
+  {
+    "name": "esritopo", "ignore": false, "alt": "Esri WorldTopoMap", "tileUrl": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+    "attribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community"
+  },
+  {
+    "name": "mtbmap_cz", "ignore": false, "alt": "MTBmap.cz", "tileUrl": "http://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png",
+    "minZoom": 1, "maxZoom": 18
+  },
+  {
+    "name": "cuzktop", "ignore": true, "alt": "ČUZK - Topografická", "tileUrl": "http://ags.cuzk.cz/arcgis/services/zmwm/MapServer/WMSServer",
+    "minZoom": 10, "maxZoom": 19, "format": "image/png", "crs": "EPSG:3857", "layers": "0", "transparent": false, "overlay": false,
+    "attribution": "© Český úřad zeměměřický a katastrální"
+  },
+  {
+    "name": "cuzksat", "ignore": true, "alt": "ČUZK - Satelitní", "tileUrl": "http://ags.cuzk.cz/arcgis/services/ortofoto_wm/MapServer/WMSServer",
+    "minZoom": 10, "maxZoom": 20, "format": "image/png", "crs": "EPSG:3857", "layers": "0", "transparent": false, "overlay": false,
+    "attribution": "© Český úřad zeměměřický a katastrální"
+  },
+  {
+    "name": "cuzkater", "ignore": true, "alt": "ČUZK - Jen terén", "tileUrl": "http://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer",
+    "minZoom": 10, "maxZoom": 20, "format": "image/png", "crs": "EPSG:4326", "layers": "dmr5g:GrayscaleHillshade", "transparent": false, "overlay": false,
+    "attribution": "© Český úřad zeměměřický a katastrální"
+  },
+  {
+    "name": "cuzklidar", "ignore": true, "alt": "ČUZK - LIDAR", "tileUrl": "http://ags.cuzk.cz/arcgis2/services/dmr5g/ImageServer/WMSServer",
+    "minZoom": 10, "maxZoom": 20, "format": "image/png", "crs": "EPSG:4326", "layers": "dmr5g:GrayscaleHillshade", "transparent": false, "overlay": false,
+    "attribution": "© Český úřad zeměměřický a katastrální"
+  },
+  {
+    "name": "googlelabels", "ignore": true, "alt": "Google labels", "tileUrl": "http://mt1.google.com/vt/lyrs=h@218000000&hl=en&src=app&x={x}&y={y}&z={z}&s=",
+    "overlay": true,
+    "attribution": "<a href='http://maps.google.com/'>Google Maps</a>"
+  },
+  {
+    "name": "popisky_m", "ignore": true, "alt": "Mapy.cz, popisky",     "tileUrl": "//mapserver.mapy.cz/hybrid-sparse-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 20, "overlay": true,
+    "attribution": "© <a href='http://www.seznam.cz' target='_blank'>Seznam.cz, a.s.</a>"
+  },
+  {
+    "name": "popisky-a-cesty_m", "ignore": true, "alt": "Mapy.cz, popisky a cesty", "tileUrl": "//mapserver.mapy.cz/hybrid-base-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 20, "overlay": true,
+    "attribution": "© <a href='http://www.seznam.cz' target='_blank'>Seznam.cz, a.s.</a>"
+  },
+  {
+    "name": "popisky-a-cyklotrasy_m", "ignore": true, "alt": "Mapy.cz, popisky a cyklotrasy", "tileUrl": "//mapserver.mapy.cz/hybrid-turist-m/{z}-{x}-{y}",
+    "minZoom": 5, "maxZoom": 20, "overlay": true,
+    "attribution": "© <a href='http://www.seznam.cz' target='_blank'>Seznam.cz, a.s.</a>"
+  }
+]


### PR DESCRIPTION
Nahrazení EKaType specifikacemi map v JSON, ve formátu, který používá GME.

Hlavní motivací je, že už nějakou dobu nefungují Seznamové mapy.

Předkládám tedy konfigurovatelnou podporu, zatím pro mapy poskytující dlaždice
podobně, jako to dělaly Mapy.cz, tj. přes URL, do kterých se dosazují souřadnice,
měřítko a případně subdoména.
- To znamená, že jsou podporovány i Mapy.cz, které ovšem ze svých důvodů nefungují,
- jsou tudíž podporovány i Google Maps, ale ty fungují jen chvilku, než začnou Geokuk
   považovat za robotický stahovač.
- Naopak nefungují mapy ČÚZK, ale snad to časem Geokuk také naučíme.

Je zohledňován atribut "ignore", takže je možné do definice umístit i aktuálně
nefungující zdroje, které ale nejsou zařazeny do nabídky.

Do umístění souborů doplněna možnost specifikovat umístění JSON souboru.
není-li tam soubor, načtou se definice z interního resource.

Co dál:
- Podpora ČÚZK map.
- Opravit načítání kachlí, aby podporovalo redirect.
- Možná vytvořit GUI pro editaci/specfikaci zdrojů map?
   - Přinejmenším aspoň možnost vybírat aktivní/neaktivní ("ignored").
- Odstranit EKaType, MapyCzUrlBuilder a OpenStreatMapUrlBuilder.